### PR TITLE
Update Biome to version 2

### DIFF
--- a/apps/api/ace.js
+++ b/apps/api/ace.js
@@ -20,6 +20,7 @@
  * Register hook to process TypeScript files using ts-node
  */
 import { register } from 'node:module';
+
 register('ts-node/esm', import.meta.url);
 
 /**

--- a/apps/api/adonisrc.ts
+++ b/apps/api/adonisrc.ts
@@ -1,6 +1,5 @@
 import { defineConfig } from '@adonisjs/core/app';
 
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default defineConfig({
 	/*
   |--------------------------------------------------------------------------

--- a/apps/api/app/analytics/analytics_provider.ts
+++ b/apps/api/app/analytics/analytics_provider.ts
@@ -1,7 +1,6 @@
 import type { ApplicationService } from '@adonisjs/core/types';
 import { ph } from './analytics_service.js';
 
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default class AnalyticsProvider {
 	constructor(protected app: ApplicationService) {}
 

--- a/apps/api/app/auth/auth_service.ts
+++ b/apps/api/app/auth/auth_service.ts
@@ -1,17 +1,17 @@
 import assert from 'node:assert/strict';
 import { inject } from '@adonisjs/core';
 import type { Session } from '@adonisjs/session';
-import {
-	generateAuthenticationOptions,
-	generateRegistrationOptions,
-	verifyAuthenticationResponse,
-	verifyRegistrationResponse,
-} from '@simplewebauthn/server';
 import type {
 	AuthenticationResponseJSON,
 	AuthenticatorTransport,
 	PublicKeyCredentialCreationOptionsJSON,
 	RegistrationResponseJSON,
+} from '@simplewebauthn/server';
+import {
+	generateAuthenticationOptions,
+	generateRegistrationOptions,
+	verifyAuthenticationResponse,
+	verifyRegistrationResponse,
 } from '@simplewebauthn/server';
 import { TRPCError } from '@trpc/server';
 import { eq } from 'drizzle-orm';
@@ -34,7 +34,6 @@ export class AuthService {
 	}): Promise<PublicKeyCredentialCreationOptionsJSON> {
 		const options: PublicKeyCredentialCreationOptionsJSON = await generateRegistrationOptions({
 			rpName: rpName,
-			// biome-ignore lint/style/useNamingConvention: This can't be renamed
 			rpID: rpId,
 			userName: input.displayName,
 			userDisplayName: input.displayName,
@@ -76,7 +75,6 @@ export class AuthService {
 			response: input.body,
 			expectedChallenge: existingChallenge,
 			expectedOrigin: origin,
-			// biome-ignore lint/style/useNamingConvention: This can't be renamed
 			expectedRPID: rpId,
 			requireUserVerification: true,
 		});
@@ -128,7 +126,6 @@ export class AuthService {
 			distinctId: userId,
 			properties: {
 				name: input.displayName,
-				// biome-ignore lint/style/useNamingConvention: This should be snake case
 				date_created: new Date(),
 			},
 		});
@@ -140,7 +137,6 @@ export class AuthService {
 
 	async getLoginOptions(session: Session) {
 		const options = await generateAuthenticationOptions({
-			// biome-ignore lint/style/useNamingConvention: This can't be renamed
 			rpID: rpId,
 			userVerification: 'preferred',
 			// Empty array allows users to auth with any passkeys they have available
@@ -153,10 +149,7 @@ export class AuthService {
 		return options;
 	}
 
-	async verifyLogin(input: {
-		body: AuthenticationResponseJSON;
-		session: Session;
-	}) {
+	async verifyLogin(input: { body: AuthenticationResponseJSON; session: Session }) {
 		const passkey = await db.query.credentials.findFirst({
 			where: eq(Schema.credentials.credentialId, input.body.id),
 			columns: {
@@ -192,7 +185,6 @@ export class AuthService {
 		const verification = await verifyAuthenticationResponse({
 			response: input.body,
 			expectedChallenge: currentChallenge,
-			// biome-ignore lint/style/useNamingConvention: This can't be renamed
 			expectedRPID: rpId,
 			expectedOrigin: origin,
 			credential: {

--- a/apps/api/app/controllers/health_checks_controller.ts
+++ b/apps/api/app/controllers/health_checks_controller.ts
@@ -2,7 +2,6 @@ import type { HttpContext } from '@adonisjs/core/http';
 import logger from '@adonisjs/core/services/logger';
 import { healthChecks } from '#start/health';
 
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default class HealthChecksController {
 	async handle({ response }: HttpContext) {
 		const report = await healthChecks.run();

--- a/apps/api/app/exceptions/handler.ts
+++ b/apps/api/app/exceptions/handler.ts
@@ -1,7 +1,6 @@
 import { Exception } from '@adonisjs/core/exceptions';
 import { ExceptionHandler, type HttpContext } from '@adonisjs/core/http';
 
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default class HttpExceptionHandler extends ExceptionHandler {
 	/**
 	 * In debug mode, the exception handler will display verbose errors

--- a/apps/api/app/middleware/container_bindings_middleware.ts
+++ b/apps/api/app/middleware/container_bindings_middleware.ts
@@ -9,7 +9,6 @@ import type { NextFn } from '@adonisjs/core/types/http';
  * - We bind "HttpContext" class to the "ctx" object
  * - And bind "Logger" class to the "ctx.logger" object
  */
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default class ContainerBindingsMiddleware {
 	handle(ctx: HttpContext, next: NextFn) {
 		ctx.containerResolver.bindValue(HttpContext, ctx);

--- a/apps/api/app/middleware/force_json_response_middleware.ts
+++ b/apps/api/app/middleware/force_json_response_middleware.ts
@@ -6,7 +6,6 @@ import type { NextFn } from '@adonisjs/core/types/http';
  * from the server. This will force the internals of the framework like
  * validator errors or auth errors to return a JSON response.
  */
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default class ForceJsonResponseMiddleware {
 	handle({ request }: HttpContext, next: NextFn) {
 		const headers = request.headers();

--- a/apps/api/app/middleware/initialize_bouncer_middleware.ts
+++ b/apps/api/app/middleware/initialize_bouncer_middleware.ts
@@ -1,11 +1,10 @@
-import * as abilities from '#abilities/main';
-import { policies } from '#policies/main';
-
 import { Bouncer } from '@adonisjs/bouncer';
 import type { BouncerAbility, Constructor, LazyImport } from '@adonisjs/bouncer/types';
 import type { HttpContext } from '@adonisjs/core/http';
 import type { NextFn } from '@adonisjs/core/types/http';
 import type { Session } from '@adonisjs/session';
+import * as abilities from '#abilities/main';
+import { policies } from '#policies/main';
 import type { UserSchema } from '../user/schemas/user_schema.js';
 
 export type BouncerUser =
@@ -23,7 +22,6 @@ export type AppBouncer = BouncerWithUser<BouncerUser, typeof abilities, typeof p
  * Init bouncer middleware is used to create a bouncer instance
  * during an HTTP request
  */
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default class InitializeBouncerMiddleware {
 	handle(ctx: HttpContext, next: NextFn) {
 		/**

--- a/apps/api/app/middleware/set_timezone_middleware.ts
+++ b/apps/api/app/middleware/set_timezone_middleware.ts
@@ -5,7 +5,6 @@ import { UserTimezoneSchema } from '../user/schemas/user_timezone_schema.js';
 /**
  * Users can include a "X-Set-Timezone" header in their request to set their timezone. This allows clients to set the timezone automatically & without prompting the user.
  */
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default class SetTimezoneMiddleware {
 	handle(ctx: HttpContext, next: NextFn) {
 		const setTimezoneHeader = ctx.request.header('x-set-timezone');

--- a/apps/api/app/policies/main.ts
+++ b/apps/api/app/policies/main.ts
@@ -13,14 +13,9 @@
 */
 
 export const policies = {
-	// biome-ignore lint/style/useNamingConvention: Convention is to use PascalCase
 	TeamMemberPolicy: () => import('./team_member_policy.js'),
-	// biome-ignore lint/style/useNamingConvention: Convention is to use PascalCase
 	UserPolicy: () => import('./user_policy.js'),
-	// biome-ignore lint/style/useNamingConvention: Convention is to use PascalCase
 	TeamPolicy: () => import('./team_policy.js'),
-	// biome-ignore lint/style/useNamingConvention: Convention is to use PascalCase
 	MeetingPolicy: () => import('./meeting_policy.js'),
-	// biome-ignore lint/style/useNamingConvention: Convention is to use PascalCase
 	TeamMemberAttendancePolicy: () => import('./team_member_attendance_policy.js'),
 };

--- a/apps/api/app/policies/meeting_policy.ts
+++ b/apps/api/app/policies/meeting_policy.ts
@@ -9,7 +9,6 @@ import type { TeamMemberSchema } from '../team_member/schemas/team_member_schema
 
 @inject()
 @injectHelper(AuthorizationService)
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default class MeetingPolicy extends BasePolicy {
 	constructor(private readonly authorizationService: AuthorizationService) {
 		super();

--- a/apps/api/app/policies/team_member_attendance_policy.ts
+++ b/apps/api/app/policies/team_member_attendance_policy.ts
@@ -9,7 +9,6 @@ import type { AttendanceEntrySchema } from '../team_member_attendance/schemas/at
 
 @inject()
 @injectHelper(AuthorizationService)
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default class TeamMemberAttendancePolicy extends BasePolicy {
 	constructor(private readonly authorizationService: AuthorizationService) {
 		super();

--- a/apps/api/app/policies/team_member_policy.ts
+++ b/apps/api/app/policies/team_member_policy.ts
@@ -9,7 +9,6 @@ import type { TeamMemberSchema } from '../team_member/schemas/team_member_schema
 
 @inject()
 @injectHelper(AuthorizationService)
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default class TeamMemberPolicy extends BasePolicy {
 	constructor(private readonly authorizationService: AuthorizationService) {
 		super();

--- a/apps/api/app/policies/team_policy.ts
+++ b/apps/api/app/policies/team_policy.ts
@@ -1,19 +1,18 @@
 import { BasePolicy } from '@adonisjs/bouncer';
 import type { AuthorizerResponse } from '@adonisjs/bouncer/types';
 import { inject } from '@adonisjs/core';
-import { P, match } from 'ts-pattern';
+import { match, P } from 'ts-pattern';
 import type { TeamManagerRole } from '#database/schema';
 import type { AppBouncer, BouncerUser } from '#middleware/initialize_bouncer_middleware';
 import { injectHelper } from '../../util/inject_helper.js';
 import { AuthorizationService } from '../authorization/authorization_service.js';
 import type { TeamSchema } from '../team/schemas/team_schema.js';
-import { type TeamManagerSchema, rolesThatCanManageOther } from '../team_manager/schemas/team_manager_schema.js';
+import { rolesThatCanManageOther, type TeamManagerSchema } from '../team_manager/schemas/team_manager_schema.js';
 import { TeamManagerService } from '../team_manager/team_manager_service.js';
 import type { UserSchema } from '../user/schemas/user_schema.js';
 
 @inject()
 @injectHelper(AuthorizationService, TeamManagerService)
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default class TeamPolicy extends BasePolicy {
 	constructor(
 		private readonly authorizationService: AuthorizationService,

--- a/apps/api/app/policies/user_policy.ts
+++ b/apps/api/app/policies/user_policy.ts
@@ -8,7 +8,6 @@ import type { UserSchema } from '../user/schemas/user_schema.js';
 
 @inject()
 @injectHelper(TeamService)
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default class UserPolicy extends BasePolicy {
 	constructor(private readonly teamService: TeamService) {
 		super();

--- a/apps/api/app/team/team_service.ts
+++ b/apps/api/app/team/team_service.ts
@@ -77,7 +77,6 @@ export class TeamService {
 					properties: {
 						name: input.displayName,
 						slug: input.slug,
-						// biome-ignore lint/style/useNamingConvention: This should be snake case
 						date_created: new Date(),
 					},
 				});

--- a/apps/api/app/team_manager/schemas/team_manager_schema.ts
+++ b/apps/api/app/team_manager/schemas/team_manager_schema.ts
@@ -1,4 +1,4 @@
-import { P, match } from 'ts-pattern';
+import { match, P } from 'ts-pattern';
 import { z } from 'zod';
 import type { TeamManagerRole } from '#database/schema';
 import { UserSchema } from '../../user/schemas/user_schema.js';

--- a/apps/api/app/team_meeting/team_meeting_service.ts
+++ b/apps/api/app/team_meeting/team_meeting_service.ts
@@ -193,7 +193,6 @@ export class TeamMeetingService {
 					company: affectedTeam.id,
 				},
 				properties: {
-					// biome-ignore lint/style/useNamingConvention: This should be snake case
 					meeting_finished: false,
 				},
 			});
@@ -247,7 +246,6 @@ export class TeamMeetingService {
 					company: affectedTeam.id,
 				},
 				properties: {
-					// biome-ignore lint/style/useNamingConvention: This should be snake case
 					meeting_finished: true,
 				},
 			});

--- a/apps/api/app/team_meeting/team_meeting_subscription_service.ts
+++ b/apps/api/app/team_meeting/team_meeting_subscription_service.ts
@@ -1,5 +1,5 @@
 import { inject } from '@adonisjs/core';
-import { type Observable, concat, filter, from, mergeMap } from 'rxjs';
+import { concat, filter, from, mergeMap, type Observable } from 'rxjs';
 import type { AppBouncer } from '#middleware/initialize_bouncer_middleware';
 import { injectHelper } from '../../util/inject_helper.js';
 import { AuthorizationService } from '../authorization/authorization_service.js';

--- a/apps/api/app/team_member/events/team_member_events_service.ts
+++ b/apps/api/app/team_member/events/team_member_events_service.ts
@@ -3,7 +3,7 @@ import logger from '@adonisjs/core/services/logger';
 import redis from '@adonisjs/redis/services/main';
 import { TRPCError } from '@trpc/server';
 import { eq, inArray } from 'drizzle-orm';
-import { type Observable, from, map, mergeMap } from 'rxjs';
+import { from, map, mergeMap, type Observable } from 'rxjs';
 import * as Schema from '#database/schema';
 import type { AppBouncer } from '#middleware/initialize_bouncer_middleware';
 import { injectHelper } from '../../../util/inject_helper.js';

--- a/apps/api/app/team_member/team_member_subscription_service.ts
+++ b/apps/api/app/team_member/team_member_subscription_service.ts
@@ -1,5 +1,5 @@
 import { inject } from '@adonisjs/core';
-import { type Observable, concat, from, mergeMap } from 'rxjs';
+import { concat, from, mergeMap, type Observable } from 'rxjs';
 import type { AppBouncer } from '#middleware/initialize_bouncer_middleware';
 import { injectHelper } from '../../util/inject_helper.js';
 import { AuthorizationService } from '../authorization/authorization_service.js';

--- a/apps/api/app/team_member_attendance/team_member_attendance_subscription_service.ts
+++ b/apps/api/app/team_member_attendance/team_member_attendance_subscription_service.ts
@@ -1,5 +1,5 @@
 import { inject } from '@adonisjs/core';
-import { type Observable, concat, filter, from, mergeMap } from 'rxjs';
+import { concat, filter, from, mergeMap, type Observable } from 'rxjs';
 import type { AppBouncer } from '#middleware/initialize_bouncer_middleware';
 import { injectHelper } from '../../util/inject_helper.js';
 import { AuthorizationService } from '../authorization/authorization_service.js';

--- a/apps/api/app/team_stats/team_stats_subscription_service.ts
+++ b/apps/api/app/team_stats/team_stats_subscription_service.ts
@@ -1,5 +1,5 @@
 import { inject } from '@adonisjs/core';
-import { type Observable, concat, filter, from, mergeMap } from 'rxjs';
+import { concat, filter, from, mergeMap, type Observable } from 'rxjs';
 import type { AppBouncer } from '#middleware/initialize_bouncer_middleware';
 import { injectHelper } from '../../util/inject_helper.js';
 import { AuthorizationService } from '../authorization/authorization_service.js';

--- a/apps/api/app/trpc/trpc_adonis_adapter.ts
+++ b/apps/api/app/trpc/trpc_adonis_adapter.ts
@@ -2,7 +2,7 @@ import { Readable } from 'node:stream';
 import type { HttpContext } from '@adonisjs/core/http';
 import type { AnyTRPCRouter, inferRouterContext } from '@trpc/server';
 import { incomingMessageToRequest } from '@trpc/server/adapters/node-http';
-import { type TRPCRequestInfo, resolveResponse } from '@trpc/server/http';
+import { resolveResponse, type TRPCRequestInfo } from '@trpc/server/http';
 import type { HTTPErrorHandler, MaybePromise } from '@trpc/server/unstable-core-do-not-import';
 
 export type CreateAdonisContextOptions = {
@@ -10,7 +10,6 @@ export type CreateAdonisContextOptions = {
 	info: TRPCRequestInfo;
 };
 
-// biome-ignore lint/style/useNamingConvention: This is in pascal case
 export type AdonisContextFn<TRouter extends AnyTRPCRouter> = (
 	opts: CreateAdonisContextOptions,
 ) => MaybePromise<inferRouterContext<TRouter>>;
@@ -33,7 +32,6 @@ function normalizePrefix(prefix: string): string {
 
 export type TrpcHandlerAdonis = (context: HttpContext) => Promise<void>;
 
-// biome-ignore lint/style/useNamingConvention: This is in pascal case
 export function createTrpcHandlerAdonis<TRouter extends AnyTRPCRouter>(options: {
 	router: TRouter;
 	prefix: string;

--- a/apps/api/app/trpc/trpc_controller.ts
+++ b/apps/api/app/trpc/trpc_controller.ts
@@ -3,12 +3,11 @@ import type { HttpContext } from '@adonisjs/core/http';
 import logger from '@adonisjs/core/services/logger';
 import { injectHelper } from '../../util/inject_helper.js';
 import { AppRouter } from '../routers/app_router.js';
-import { type TrpcHandlerAdonis, createTrpcHandlerAdonis } from './trpc_adonis_adapter.js';
+import { createTrpcHandlerAdonis, type TrpcHandlerAdonis } from './trpc_adonis_adapter.js';
 import { createHttpContext } from './trpc_context.js';
 
 @inject()
 @injectHelper(AppRouter)
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default class TrpcController {
 	private readonly handler: TrpcHandlerAdonis;
 

--- a/apps/api/app/trpc/trpc_service.ts
+++ b/apps/api/app/trpc/trpc_service.ts
@@ -1,4 +1,4 @@
-import { TRPCError, initTRPC } from '@trpc/server';
+import { initTRPC, TRPCError } from '@trpc/server';
 import superjson from 'superjson';
 import type { createHttpContext } from './trpc_context.js';
 

--- a/apps/api/config/bodyparser.ts
+++ b/apps/api/config/bodyparser.ts
@@ -47,5 +47,4 @@ const bodyParserConfig = defineConfig({
 	},
 });
 
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default bodyParserConfig;

--- a/apps/api/config/cors.ts
+++ b/apps/api/config/cors.ts
@@ -16,5 +16,4 @@ const corsConfig = defineConfig({
 	maxAge: 90,
 });
 
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default corsConfig;

--- a/apps/api/config/hash.ts
+++ b/apps/api/config/hash.ts
@@ -13,7 +13,6 @@ const hashConfig = defineConfig({
 	},
 });
 
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default hashConfig;
 
 /**
@@ -21,6 +20,5 @@ export default hashConfig;
  * in your application.
  */
 declare module '@adonisjs/core/types' {
-	// biome-ignore lint/correctness/noUndeclaredVariables: This doesn't need to be imported
 	export interface HashersList extends InferHashers<typeof hashConfig> {}
 }

--- a/apps/api/config/logger.ts
+++ b/apps/api/config/logger.ts
@@ -24,7 +24,6 @@ const loggerConfig = defineConfig({
 	},
 });
 
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default loggerConfig;
 
 /**
@@ -32,6 +31,5 @@ export default loggerConfig;
  * in your application.
  */
 declare module '@adonisjs/core/types' {
-	// biome-ignore lint/correctness/noUndeclaredVariables: This doesn't need to be imported
 	export interface LoggersList extends InferLoggers<typeof loggerConfig> {}
 }

--- a/apps/api/config/redis.ts
+++ b/apps/api/config/redis.ts
@@ -32,7 +32,6 @@ const redisConfig = defineConfig({
 	},
 });
 
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default redisConfig;
 
 declare module '@adonisjs/redis/types' {

--- a/apps/api/config/sentry.ts
+++ b/apps/api/config/sentry.ts
@@ -2,7 +2,6 @@ import app from '@adonisjs/core/services/app';
 import { defineConfig } from '@rlanz/sentry';
 import env from '#start/env';
 
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default defineConfig({
 	/**
 	 * Enable or disable Sentry

--- a/apps/api/config/session.ts
+++ b/apps/api/config/session.ts
@@ -49,5 +49,4 @@ const sessionConfig = defineConfig({
 	},
 });
 
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default sessionConfig;

--- a/apps/api/drizzle.config.ts
+++ b/apps/api/drizzle.config.ts
@@ -11,7 +11,6 @@ const postgresUrl = process.env.POSTGRES_URL;
 
 assert(postgresUrl, new TypeError('POSTGRES_URL environment variable was not set'));
 
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default defineConfig({
 	schema: path.join('database', 'schema.ts'),
 	dialect: 'postgresql',

--- a/apps/api/start/env.ts
+++ b/apps/api/start/env.ts
@@ -11,28 +11,17 @@
 
 import { Env } from '@adonisjs/core/env';
 
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default await Env.create(new URL('../../../', import.meta.url), {
-	// biome-ignore lint/style/useNamingConvention: These are environment variables
 	NODE_ENV: Env.schema.enum(['development', 'production', 'staging'] as const),
-	// biome-ignore lint/style/useNamingConvention: These are environment variables
 	PORT: Env.schema.number.optional(),
-	// biome-ignore lint/style/useNamingConvention: These are environment variables
 	APP_KEY: Env.schema.string(),
-	// biome-ignore lint/style/useNamingConvention: These are environment variables
 	HOST: Env.schema.string.optional({ format: 'host' }),
-	// biome-ignore lint/style/useNamingConvention: These are environment variables
 	LOG_LEVEL: Env.schema.enum.optional(['fatal', 'error', 'warn', 'info', 'debug', 'trace']),
-	// biome-ignore lint/style/useNamingConvention: These are environment variables
 	POSTGRES_URL: Env.schema.string(),
-	// biome-ignore lint/style/useNamingConvention: These are environment variables
 	REDIS_URL: Env.schema.string(),
-	// biome-ignore lint/style/useNamingConvention: These are environment variables
 	COOKIE_DOMAIN: Env.schema.string({ format: 'host' }),
 
-	// biome-ignore lint/style/useNamingConvention: These are environment variables
 	POSTHOG_HOST: Env.schema.string(),
-	// biome-ignore lint/style/useNamingConvention: These are environment variables
 	POSTHOG_KEY: Env.schema.string(),
 
 	/*
@@ -40,6 +29,5 @@ export default await Env.create(new URL('../../../', import.meta.url), {
   | Variables for configuring @rlanz/sentry package
   |----------------------------------------------------------
   */
-	// biome-ignore lint/style/useNamingConvention: These are environment variables
 	SENTRY_DSN_API: Env.schema.string(),
 });

--- a/apps/web/components/ui/badge.tsx
+++ b/apps/web/components/ui/badge.tsx
@@ -1,4 +1,4 @@
-import { type VariantProps, cva } from 'class-variance-authority';
+import { cva, type VariantProps } from 'class-variance-authority';
 import type * as React from 'react';
 
 import { cn } from '@/lib/utils';

--- a/apps/web/components/ui/button.tsx
+++ b/apps/web/components/ui/button.tsx
@@ -1,5 +1,5 @@
 import { Slot } from '@radix-ui/react-slot';
-import { type VariantProps, cva } from 'class-variance-authority';
+import { cva, type VariantProps } from 'class-variance-authority';
 import * as React from 'react';
 
 import { cn } from '@/lib/utils';

--- a/apps/web/components/ui/calendar.tsx
+++ b/apps/web/components/ui/calendar.tsx
@@ -18,22 +18,16 @@ function Calendar({ className, classNames, showOutsideDays = true, ...props }: C
 				months: 'flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0',
 				month: 'space-y-4',
 				caption: 'flex justify-center pt-1 relative items-center',
-				// biome-ignore lint/style/useNamingConvention: This can't be renamed
 				caption_label: 'text-sm font-medium',
 				nav: 'space-x-1 flex items-center',
-				// biome-ignore lint/style/useNamingConvention: This can't be renamed
 				nav_button: cn(
 					buttonVariants({ variant: 'outline' }),
 					'h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100',
 				),
-				// biome-ignore lint/style/useNamingConvention: This can't be renamed
 				nav_button_previous: 'absolute left-1',
-				// biome-ignore lint/style/useNamingConvention: This can't be renamed
 				nav_button_next: 'absolute right-1',
 				table: 'w-full border-collapse space-y-1',
-				// biome-ignore lint/style/useNamingConvention: This can't be renamed
 				head_row: 'flex',
-				// biome-ignore lint/style/useNamingConvention: This can't be renamed
 				head_cell: 'text-muted-foreground rounded-md w-8 font-normal text-[0.8rem]',
 				row: 'flex w-full mt-2',
 				cell: cn(
@@ -43,30 +37,20 @@ function Calendar({ className, classNames, showOutsideDays = true, ...props }: C
 						: '[&:has([aria-selected])]:rounded-md',
 				),
 				day: cn(buttonVariants({ variant: 'ghost' }), 'h-8 w-8 p-0 font-normal aria-selected:opacity-100'),
-				// biome-ignore lint/style/useNamingConvention: This can't be renamed
 				day_range_start: 'day-range-start',
-				// biome-ignore lint/style/useNamingConvention: This can't be renamed
 				day_range_end: 'day-range-end',
-				// biome-ignore lint/style/useNamingConvention: This can't be renamed
 				day_selected:
 					'bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground',
-				// biome-ignore lint/style/useNamingConvention: This can't be renamed
 				day_today: 'bg-accent text-accent-foreground',
-				// biome-ignore lint/style/useNamingConvention: This can't be renamed
 				day_outside:
 					'day-outside text-muted-foreground opacity-50  aria-selected:bg-accent/50 aria-selected:text-muted-foreground aria-selected:opacity-30',
-				// biome-ignore lint/style/useNamingConvention: This can't be renamed
 				day_disabled: 'text-muted-foreground opacity-50',
-				// biome-ignore lint/style/useNamingConvention: This can't be renamed
 				day_range_middle: 'aria-selected:bg-accent aria-selected:text-accent-foreground',
-				// biome-ignore lint/style/useNamingConvention: This can't be renamed
 				day_hidden: 'invisible',
 				...classNames,
 			}}
 			components={{
-				// biome-ignore lint/style/useNamingConvention: This can't be renamed
 				IconLeft: () => <ChevronLeftIcon className='h-4 w-4' />,
-				// biome-ignore lint/style/useNamingConvention: This can't be renamed
 				IconRight: () => <ChevronRightIcon className='h-4 w-4' />,
 			}}
 			{...props}

--- a/apps/web/components/ui/chart.tsx
+++ b/apps/web/components/ui/chart.tsx
@@ -165,7 +165,6 @@ const ChartTooltipContent = React.forwardRef<
 			>
 				{nestLabel ? null : tooltipLabel}
 				<div className='grid gap-1.5'>
-					{/* biome-ignore lint/complexity/noExcessiveCognitiveComplexity: This is not my code and I will not be attempting to improve it */}
 					{payload.map((item, index) => {
 						const key = `${nameKey || item.name || item.dataKey || 'value'}`;
 						const itemConfig = getPayloadConfigFromPayload(config, item, key);

--- a/apps/web/components/ui/checkbox.tsx
+++ b/apps/web/components/ui/checkbox.tsx
@@ -1,10 +1,9 @@
 'use client';
 
+import { CheckIcon, MinusIcon } from '@heroicons/react/16/solid';
 import * as CheckboxPrimitive from '@radix-ui/react-checkbox';
 import * as React from 'react';
-
 import { cn } from '@/lib/utils';
-import { CheckIcon, MinusIcon } from '@heroicons/react/16/solid';
 
 const Checkbox = React.forwardRef<
 	React.ElementRef<typeof CheckboxPrimitive.Root>,

--- a/apps/web/components/ui/dialog.tsx
+++ b/apps/web/components/ui/dialog.tsx
@@ -1,10 +1,9 @@
 'use client';
 
+import { XMarkIcon } from '@heroicons/react/16/solid';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import * as React from 'react';
-
 import { cn } from '@/lib/utils';
-import { XMarkIcon } from '@heroicons/react/16/solid';
 
 const Dialog = DialogPrimitive.Root;
 

--- a/apps/web/components/ui/dropdown-menu.tsx
+++ b/apps/web/components/ui/dropdown-menu.tsx
@@ -1,11 +1,10 @@
 'use client';
 
+import { CheckIcon, ChevronRightIcon } from '@heroicons/react/16/solid';
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
 import { DotFilledIcon } from '@radix-ui/react-icons';
 import * as React from 'react';
-
 import { cn } from '@/lib/utils';
-import { CheckIcon, ChevronRightIcon } from '@heroicons/react/16/solid';
 
 const DropdownMenu = DropdownMenuPrimitive.Root;
 

--- a/apps/web/components/ui/flex-table.tsx
+++ b/apps/web/components/ui/flex-table.tsx
@@ -1,5 +1,5 @@
-import { cn } from '@/lib/utils';
 import * as React from 'react';
+import { cn } from '@/lib/utils';
 
 const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(
 	({ className, ...props }, ref) => (

--- a/apps/web/components/ui/form.tsx
+++ b/apps/web/components/ui/form.tsx
@@ -16,9 +16,7 @@ import { cn } from '@/lib/utils';
 const Form = FormProvider;
 
 type FormFieldContextValue<
-	// biome-ignore lint/style/useNamingConvention: This is in pascal case
 	TFieldValues extends FieldValues = FieldValues,
-	// biome-ignore lint/style/useNamingConvention: This is in pascal case
 	TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
 > = {
 	name: TName;
@@ -27,9 +25,7 @@ type FormFieldContextValue<
 const FormFieldContext = React.createContext<FormFieldContextValue>({} as FormFieldContextValue);
 
 const FormField = <
-	// biome-ignore lint/style/useNamingConvention: This is in pascal case
 	TFieldValues extends FieldValues = FieldValues,
-	// biome-ignore lint/style/useNamingConvention: This is in pascal case
 	TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
 >({
 	...props

--- a/apps/web/components/ui/label.tsx
+++ b/apps/web/components/ui/label.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as LabelPrimitive from '@radix-ui/react-label';
-import { type VariantProps, cva } from 'class-variance-authority';
+import { cva, type VariantProps } from 'class-variance-authority';
 import * as React from 'react';
 
 import { cn } from '@/lib/utils';

--- a/apps/web/components/ui/select.tsx
+++ b/apps/web/components/ui/select.tsx
@@ -1,11 +1,9 @@
 'use client';
 
+import { CheckIcon, ChevronDownIcon, ChevronUpDownIcon, ChevronUpIcon } from '@heroicons/react/16/solid';
 import * as SelectPrimitive from '@radix-ui/react-select';
 import * as React from 'react';
-
 import { cn } from '@/lib/utils';
-
-import { CheckIcon, ChevronDownIcon, ChevronUpDownIcon, ChevronUpIcon } from '@heroicons/react/16/solid';
 
 const Select = SelectPrimitive.Root;
 

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -12,11 +12,8 @@ module.exports = withSentryConfig(
 	withPlausibleProxy()({
 		productionBrowserSourceMaps: true,
 		env: {
-			// biome-ignore lint/style/useNamingConvention: This is an environment variable
 			NEXT_PUBLIC_API_URL: getBaseApiUrl(),
-			// biome-ignore lint/style/useNamingConvention: This is an environment variable
 			POSTHOG_HOST: process.env.POSTHOG_HOST,
-			// biome-ignore lint/style/useNamingConvention: This is an environment variable
 			POSTHOG_KEY: process.env.POSTHOG_KEY,
 		},
 		// Needed for a Next.js bug https://github.com/vercel/next.js/discussions/32237#discussioncomment-4793595

--- a/apps/web/src/app/(auth)/layout.tsx
+++ b/apps/web/src/app/(auth)/layout.tsx
@@ -1,9 +1,8 @@
+import type { PropsWithChildren } from 'react';
 import { Navbar } from '@/src/components/navbar/navbar';
 import { FooterWrapper } from '@/src/components/page-wrappers/footer-wrapper';
 import { MainContent } from '@/src/components/page-wrappers/main-content';
-import type { PropsWithChildren } from 'react';
 
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default function AuthPageLayout({ children }: PropsWithChildren) {
 	return (
 		<FooterWrapper>

--- a/apps/web/src/app/(auth)/login/page.tsx
+++ b/apps/web/src/app/(auth)/login/page.tsx
@@ -1,12 +1,11 @@
+import { ArrowRightIcon } from '@heroicons/react/16/solid';
+import { unstable_noStore as noStore } from 'next/cache';
+import { Link } from 'next-view-transitions';
 import { Button } from '@/components/ui/button';
 import { AlreadyAuthedCard } from '@/src/components/account/already-authed-card/already-authed-card';
 import { LoginCard } from '@/src/components/account/login/login-card';
 import { trpcServer } from '@/src/trpc/trpc-server';
-import { ArrowRightIcon } from '@heroicons/react/16/solid';
-import { Link } from 'next-view-transitions';
-import { unstable_noStore as noStore } from 'next/cache';
 
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default async function LoginPage() {
 	noStore();
 	const { user } = await trpcServer.user.getSelf.query();

--- a/apps/web/src/app/(auth)/signup/page.tsx
+++ b/apps/web/src/app/(auth)/signup/page.tsx
@@ -1,12 +1,11 @@
+import { ArrowRightIcon } from '@heroicons/react/16/solid';
+import { unstable_noStore as noStore } from 'next/cache';
+import { Link } from 'next-view-transitions';
 import { Button } from '@/components/ui/button';
 import { AlreadyAuthedCard } from '@/src/components/account/already-authed-card/already-authed-card';
 import { SignupCard } from '@/src/components/account/signup/signup-card';
 import { trpcServer } from '@/src/trpc/trpc-server';
-import { ArrowRightIcon } from '@heroicons/react/16/solid';
-import { Link } from 'next-view-transitions';
-import { unstable_noStore as noStore } from 'next/cache';
 
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default async function SignupPage() {
 	noStore();
 

--- a/apps/web/src/app/account/layout.tsx
+++ b/apps/web/src/app/account/layout.tsx
@@ -1,10 +1,9 @@
+import type { PropsWithChildren } from 'react';
 import { Navbar } from '@/src/components/navbar/navbar';
 import { PageHeader } from '@/src/components/page-header';
 import { FooterWrapper } from '@/src/components/page-wrappers/footer-wrapper';
 import { MainContent } from '@/src/components/page-wrappers/main-content';
-import type { PropsWithChildren } from 'react';
 
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default function AccountPageLayout({ children }: PropsWithChildren) {
 	return (
 		<FooterWrapper>

--- a/apps/web/src/app/account/page.tsx
+++ b/apps/web/src/app/account/page.tsx
@@ -2,7 +2,6 @@ import { DeleteAccountCard } from '@/src/components/account/settings/delete-acco
 import { DisplayNameCard } from '@/src/components/account/settings/display-name-card/display-name-card.server';
 import { AuthWall } from '@/src/components/auth-wall/auth-wall';
 
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default function ProfilePage() {
 	return (
 		<AuthWall kind='user'>

--- a/apps/web/src/app/error.tsx
+++ b/apps/web/src/app/error.tsx
@@ -1,21 +1,14 @@
 'use client';
 
-import { Button } from '@/components/ui/button';
 import { captureException } from '@sentry/nextjs';
 import { useEffect } from 'react';
+import { Button } from '@/components/ui/button';
 import { BaseNavbar } from '../components/navbar/base-navbar';
 import { PageHeader } from '../components/page-header';
 import { FooterWrapper } from '../components/page-wrappers/footer-wrapper';
 import { MainContent } from '../components/page-wrappers/main-content';
 
-// biome-ignore lint/style/noDefaultExport: This must be a default export
-export default function ErrorPage({
-	error,
-	reset,
-}: {
-	error: Error & { digest?: string };
-	reset: () => void;
-}) {
+export default function ErrorPage({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
 	useEffect(() => {
 		captureException(error);
 	}, [error]);

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -5,7 +5,6 @@ import NextError from 'next/error';
 import { useEffect } from 'react';
 import { isTrpcClientError } from '../trpc/common';
 
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default function GlobalError({ error }: { error: Error & { digest?: string } }) {
 	useEffect(() => {
 		if (error instanceof AggregateError) {

--- a/apps/web/src/app/home/page.tsx
+++ b/apps/web/src/app/home/page.tsx
@@ -1,3 +1,6 @@
+import clsx from 'clsx';
+import type { Metadata } from 'next';
+import { Link } from 'next-view-transitions';
 import { buttonVariants } from '@/components/ui/button';
 import { LandingAttendanceSection } from '@/src/components/landing/attendance/landing-attendance-section';
 import { LandingCtaSection } from '@/src/components/landing/cta/landing-cta-section';
@@ -6,9 +9,6 @@ import { LandingInsightsSection } from '@/src/components/landing/insights/landin
 import { Navbar } from '@/src/components/navbar/navbar';
 import { FooterWrapper } from '@/src/components/page-wrappers/footer-wrapper';
 import { siteMetadata } from '@/src/site-metadata';
-import clsx from 'clsx';
-import type { Metadata } from 'next';
-import { Link } from 'next-view-transitions';
 import dotsStyles from '../../components/dots/dots.module.css';
 
 export const metadata: Metadata = {
@@ -18,7 +18,6 @@ export const metadata: Metadata = {
 	},
 };
 
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default function LandingPage() {
 	return (
 		<FooterWrapper themeProps={{ forcedTheme: 'dark' }}>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,12 +1,12 @@
-import { Toaster } from '@/components/ui/sonner';
-import { TooltipProvider } from '@/components/ui/tooltip';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import clsx from 'clsx';
 import type { Metadata, Viewport } from 'next';
+import { Inter, Playfair_Display } from 'next/font/google';
 import PlausibleProvider from 'next-plausible';
 import { ViewTransitions } from 'next-view-transitions';
-import { Inter, Playfair_Display } from 'next/font/google';
 import { NuqsAdapter } from 'nuqs/adapters/next/app';
+import { Toaster } from '@/components/ui/sonner';
+import { TooltipProvider } from '@/components/ui/tooltip';
 import '../globals.css';
 import { PostHogIdentityProvider } from '../providers/post-hog-identity-provider';
 import { PostHogPageView } from '../providers/post-hog-page-view';
@@ -55,7 +55,6 @@ const playfairDisplay = Playfair_Display({
 });
 const inter = Inter({ subsets: ['latin'], weight: 'variable', variable: '--font-inter', display: 'swap' });
 
-// biome-ignore lint/style/noDefaultExport: This has to be a default export
 export default function RootLayout({ children }: { children: React.ReactNode }) {
 	return (
 		<ViewTransitions>

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -3,7 +3,6 @@ import { NotFoundPageContent } from '../components/not-found-content';
 import { FooterWrapper } from '../components/page-wrappers/footer-wrapper';
 import { MainContent } from '../components/page-wrappers/main-content';
 
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default function NotFoundPage() {
 	return (
 		<FooterWrapper>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,11 +1,11 @@
+import { captureException } from '@sentry/nextjs';
+import { unstable_noStore as noStore } from 'next/cache';
+import { cookies } from 'next/headers';
 import { TeamCards } from '@/src/components/home/team-cards';
 import { Navbar } from '@/src/components/navbar/navbar';
 import { FooterWrapper } from '@/src/components/page-wrappers/footer-wrapper';
 import { MainContent } from '@/src/components/page-wrappers/main-content';
 import { trpcServer } from '@/src/trpc/trpc-server';
-import { captureException } from '@sentry/nextjs';
-import { unstable_noStore as noStore } from 'next/cache';
-import { cookies } from 'next/headers';
 import LandingPage from './home/page';
 
 function AuthedHomePage() {
@@ -22,7 +22,6 @@ function AuthedHomePage() {
 	);
 }
 
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default async function HomePage() {
 	noStore();
 

--- a/apps/web/src/app/team/(create)/layout.tsx
+++ b/apps/web/src/app/team/(create)/layout.tsx
@@ -1,12 +1,10 @@
+import type { PropsWithChildren } from 'react';
 import { AuthWall } from '@/src/components/auth-wall/auth-wall';
 import { Navbar } from '@/src/components/navbar/navbar';
-
 import { PageHeader } from '@/src/components/page-header';
 import { FooterWrapper } from '@/src/components/page-wrappers/footer-wrapper';
 import { MainContent } from '@/src/components/page-wrappers/main-content';
-import type { PropsWithChildren } from 'react';
 
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default function TeamCreatePageLayout({ children }: PropsWithChildren) {
 	return (
 		<FooterWrapper>

--- a/apps/web/src/app/team/(create)/page.tsx
+++ b/apps/web/src/app/team/(create)/page.tsx
@@ -1,11 +1,5 @@
 'use client';
 
-import { Button } from '@/components/ui/button';
-import { Form } from '@/components/ui/form';
-import { CreateTeamNameCard } from '@/src/components/create-team/form/create-team-name-card';
-import { CreateTeamPasswordCard } from '@/src/components/create-team/form/create-team-password';
-import { CreateTeamUrlCard } from '@/src/components/create-team/form/create-team-url-card';
-import { trpc } from '@/src/trpc/trpc-client';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import { useRouter } from 'next/navigation';
@@ -13,12 +7,17 @@ import { useState } from 'react';
 import { type UseFormReturn, useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import type { z } from 'zod';
+import { Button } from '@/components/ui/button';
+import { Form } from '@/components/ui/form';
+import { CreateTeamNameCard } from '@/src/components/create-team/form/create-team-name-card';
+import { CreateTeamPasswordCard } from '@/src/components/create-team/form/create-team-password';
+import { CreateTeamUrlCard } from '@/src/components/create-team/form/create-team-url-card';
+import { trpc } from '@/src/trpc/trpc-client';
 
 const formSchema = TeamSchema.pick({ displayName: true, password: true, slug: true });
 
 export type CreateTeamFormType = UseFormReturn<z.infer<typeof formSchema>, unknown, undefined>;
 
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default function CreateTeamPage() {
 	const router = useRouter();
 	const form: CreateTeamFormType = useForm({

--- a/apps/web/src/app/team/[team]/(attendance)/layout.tsx
+++ b/apps/web/src/app/team/[team]/(attendance)/layout.tsx
@@ -1,11 +1,10 @@
+import { notFound } from 'next/navigation';
+import type { PropsWithChildren } from 'react';
 import { AuthWall } from '@/src/components/auth-wall/auth-wall';
 import { Navbar } from '@/src/components/navbar/navbar';
 import { MainContent } from '@/src/components/page-wrappers/main-content';
-
 import { isTrpcClientError } from '@/src/trpc/common';
 import { trpcServer } from '@/src/trpc/trpc-server';
-import { notFound } from 'next/navigation';
-import type { PropsWithChildren } from 'react';
 
 type Props = PropsWithChildren<{
 	params: Promise<{
@@ -13,7 +12,6 @@ type Props = PropsWithChildren<{
 	}>;
 }>;
 
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default async function TeamAttendanceLayout(props: Props) {
 	const params = await props.params;
 

--- a/apps/web/src/app/team/[team]/(attendance)/page.tsx
+++ b/apps/web/src/app/team/[team]/(attendance)/page.tsx
@@ -1,8 +1,8 @@
+import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
+import { Suspense } from 'react';
 import { AttendanceTable } from '@/src/components/team-dashboard/attendance-table/attendance-table';
 import { ManagerTiles } from '@/src/components/team-dashboard/manager-tiles/manager-tiles';
 import { trpcServer } from '@/src/trpc/trpc-server';
-import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
-import { Suspense } from 'react';
 
 type Props = {
 	params: Promise<{
@@ -20,7 +20,6 @@ async function ManagerTilesWrapper({ team }: { team: Pick<TeamSchema, 'slug'> })
 	return undefined;
 }
 
-// biome-ignore lint/style/noDefaultExport: This has to be a default export
 export default async function TeamAttendancePage(props: Props) {
 	const params = await props.params;
 	const team = { slug: params.team };

--- a/apps/web/src/app/team/[team]/dashboard/(dashboard)/(members)/page.tsx
+++ b/apps/web/src/app/team/[team]/dashboard/(dashboard)/(members)/page.tsx
@@ -8,7 +8,6 @@ type Props = {
 	searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 };
 
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default async function ManagerPageMembersTab(props: Props) {
 	const searchParams = await props.searchParams;
 	const params = await props.params;

--- a/apps/web/src/app/team/[team]/dashboard/(dashboard)/hours/page.tsx
+++ b/apps/web/src/app/team/[team]/dashboard/(dashboard)/hours/page.tsx
@@ -8,7 +8,6 @@ type Props = {
 	searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 };
 
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default async function ManagerPageHoursTab(props: Props) {
 	const searchParams = await props.searchParams;
 	const params = await props.params;

--- a/apps/web/src/app/team/[team]/dashboard/(dashboard)/layout.tsx
+++ b/apps/web/src/app/team/[team]/dashboard/(dashboard)/layout.tsx
@@ -1,9 +1,9 @@
+import type { PropsWithChildren } from 'react';
 import { ManagerDashboardProvider } from '@/src/components/manager/dashboard/manager-dashboard-context';
 import { ManagerDashboardPeriodSelect } from '@/src/components/manager/dashboard/period-select';
 import { EndMeetingButton } from '@/src/components/manager/end-meeting-button/end-meeting-button';
 import { PageHeader } from '@/src/components/page-header';
 import { MainContent } from '@/src/components/page-wrappers/main-content';
-import type { PropsWithChildren } from 'react';
 
 type Props = PropsWithChildren<{
 	params: Promise<{
@@ -11,7 +11,6 @@ type Props = PropsWithChildren<{
 	}>;
 }>;
 
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default async function ManagerDashboardLayout(props: Props) {
 	const params = await props.params;
 

--- a/apps/web/src/app/team/[team]/dashboard/layout.tsx
+++ b/apps/web/src/app/team/[team]/dashboard/layout.tsx
@@ -1,10 +1,10 @@
+import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
+import { notFound } from 'next/navigation';
+import type { PropsWithChildren } from 'react';
 import { AuthWall } from '@/src/components/auth-wall/auth-wall';
 import { ManagerNavbar } from '@/src/components/manager/navbar/manager-navbar';
 import { isTrpcClientError } from '@/src/trpc/common';
 import { trpcServer } from '@/src/trpc/trpc-server';
-import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
-import { notFound } from 'next/navigation';
-import type { PropsWithChildren } from 'react';
 
 type Props = PropsWithChildren<{
 	params: Promise<{
@@ -12,7 +12,6 @@ type Props = PropsWithChildren<{
 	}>;
 }>;
 
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default async function ManagerLayout(props: Props) {
 	const params = await props.params;
 

--- a/apps/web/src/app/team/[team]/dashboard/meetings/layout.tsx
+++ b/apps/web/src/app/team/[team]/dashboard/meetings/layout.tsx
@@ -1,8 +1,8 @@
+import type { PropsWithChildren } from 'react';
 import { CreateMeetingDialog } from '@/src/components/manager/meetings/create-meeting-dialog/create-meeting-dialog';
 import { DownloadMeetingsCsvButton } from '@/src/components/manager/meetings/download-meetings-csv-button';
 import { PageHeader } from '@/src/components/page-header';
 import { MainContent } from '@/src/components/page-wrappers/main-content';
-import type { PropsWithChildren } from 'react';
 
 type Props = PropsWithChildren<{
 	params: Promise<{
@@ -10,7 +10,6 @@ type Props = PropsWithChildren<{
 	}>;
 }>;
 
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default async function ManagerMeetingsPageLayout(props: Props) {
 	const params = await props.params;
 

--- a/apps/web/src/app/team/[team]/dashboard/meetings/page.tsx
+++ b/apps/web/src/app/team/[team]/dashboard/meetings/page.tsx
@@ -1,7 +1,7 @@
+import type { SearchParams } from 'nuqs';
 import { MeetingsTable } from '@/src/components/manager/meetings/meetings-table/meetings-table';
 import { searchParamCache } from '@/src/components/manager/meetings/search-params';
 import { toTimeFilter } from '@/src/components/manager/period-select/duration-slug';
-import type { SearchParams } from 'nuqs';
 
 type Props = {
 	params: Promise<{
@@ -10,7 +10,6 @@ type Props = {
 	searchParams: Promise<SearchParams>;
 };
 
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default async function ManagerMeetingsPage(props: Props) {
 	const searchParams = await props.searchParams;
 	const params = await props.params;

--- a/apps/web/src/app/team/[team]/dashboard/members/(all-members)/layout.tsx
+++ b/apps/web/src/app/team/[team]/dashboard/members/(all-members)/layout.tsx
@@ -1,8 +1,8 @@
+import { PlusIcon } from '@heroicons/react/16/solid';
+import type { PropsWithChildren } from 'react';
 import { CreateMemberDialog } from '@/src/components/members/create-member/create-member-dialog';
 import { PageHeader } from '@/src/components/page-header';
 import { MainContent } from '@/src/components/page-wrappers/main-content';
-import { PlusIcon } from '@heroicons/react/16/solid';
-import type { PropsWithChildren } from 'react';
 
 type Props = PropsWithChildren<{
 	params: Promise<{
@@ -10,7 +10,6 @@ type Props = PropsWithChildren<{
 	}>;
 }>;
 
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default async function ManagerMembersPageLayout(props: Props) {
 	const params = await props.params;
 

--- a/apps/web/src/app/team/[team]/dashboard/members/(all-members)/page.tsx
+++ b/apps/web/src/app/team/[team]/dashboard/members/(all-members)/page.tsx
@@ -6,7 +6,6 @@ type Props = {
 	}>;
 };
 
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default async function ManagerMembersPage(props: Props) {
 	const params = await props.params;
 	const team = { slug: params.team };

--- a/apps/web/src/app/team/[team]/dashboard/members/[member]/page.tsx
+++ b/apps/web/src/app/team/[team]/dashboard/members/[member]/page.tsx
@@ -11,7 +11,6 @@ type Props = {
 	searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 };
 
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default async function ViewMemberPage(props: Props) {
 	const searchParams = await props.searchParams;
 	const params = await props.params;

--- a/apps/web/src/app/team/[team]/dashboard/settings/(general)/layout.tsx
+++ b/apps/web/src/app/team/[team]/dashboard/settings/(general)/layout.tsx
@@ -1,5 +1,5 @@
-import { TeamSettingsPageContainer } from '@/src/components/manager/settings/page-container';
 import type { PropsWithChildren } from 'react';
+import { TeamSettingsPageContainer } from '@/src/components/manager/settings/page-container';
 
 type Props = PropsWithChildren<{
 	params: Promise<{
@@ -7,7 +7,6 @@ type Props = PropsWithChildren<{
 	}>;
 }>;
 
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default async function TeamSettingsGeneralLayout(props: Props) {
 	const params = await props.params;
 

--- a/apps/web/src/app/team/[team]/dashboard/settings/(general)/page.tsx
+++ b/apps/web/src/app/team/[team]/dashboard/settings/(general)/page.tsx
@@ -10,7 +10,6 @@ type Props = {
 	}>;
 };
 
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default async function TeamSettingsGeneralPage(props: Props) {
 	const params = await props.params;
 	const team = { slug: params.team };

--- a/apps/web/src/app/team/[team]/dashboard/settings/layout.tsx
+++ b/apps/web/src/app/team/[team]/dashboard/settings/layout.tsx
@@ -1,8 +1,7 @@
+import type { PropsWithChildren } from 'react';
 import { PageHeader } from '@/src/components/page-header';
 import { MainContent } from '@/src/components/page-wrappers/main-content';
-import type { PropsWithChildren } from 'react';
 
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default function SettingsLayout({ children }: PropsWithChildren) {
 	return (
 		<>

--- a/apps/web/src/app/team/[team]/dashboard/settings/managers/layout.tsx
+++ b/apps/web/src/app/team/[team]/dashboard/settings/managers/layout.tsx
@@ -1,5 +1,5 @@
-import { TeamSettingsPageContainer } from '@/src/components/manager/settings/page-container';
 import type { PropsWithChildren } from 'react';
+import { TeamSettingsPageContainer } from '@/src/components/manager/settings/page-container';
 
 type Props = PropsWithChildren<{
 	params: Promise<{
@@ -7,7 +7,6 @@ type Props = PropsWithChildren<{
 	}>;
 }>;
 
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default async function TeamSettingsManagersLayout(props: Props) {
 	const params = await props.params;
 

--- a/apps/web/src/app/team/[team]/dashboard/settings/managers/page.tsx
+++ b/apps/web/src/app/team/[team]/dashboard/settings/managers/page.tsx
@@ -7,7 +7,6 @@ type Props = {
 	}>;
 };
 
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default async function TeamSettingsManagersPage(props: Props) {
 	const params = await props.params;
 	const team = { slug: params.team };

--- a/apps/web/src/app/team/[team]/layout.tsx
+++ b/apps/web/src/app/team/[team]/layout.tsx
@@ -1,6 +1,6 @@
+import type { PropsWithChildren } from 'react';
 import { FooterWrapper } from '@/src/components/page-wrappers/footer-wrapper';
 import { TeamSlugProvider } from '@/src/components/team-dashboard/team-slug-provider';
-import type { PropsWithChildren } from 'react';
 
 type Props = PropsWithChildren<{
 	params: Promise<{
@@ -8,7 +8,6 @@ type Props = PropsWithChildren<{
 	}>;
 }>;
 
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default async function TeamPageLayout(props: Props) {
 	const params = await props.params;
 

--- a/apps/web/src/app/team/[team]/login/page.tsx
+++ b/apps/web/src/app/team/[team]/login/page.tsx
@@ -1,15 +1,14 @@
+import { ArrowRightIcon } from '@heroicons/react/16/solid';
+import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
+import { notFound } from 'next/navigation';
+import { Link } from 'next-view-transitions';
 import { Button } from '@/components/ui/button';
 import { Navbar } from '@/src/components/navbar/navbar';
 import { MainContent } from '@/src/components/page-wrappers/main-content';
 import { AlreadyAuthedCard } from '@/src/components/team-dashboard/password-login/already-authed-card';
-
 import { PasswordLoginCard } from '@/src/components/team-dashboard/password-login/password-login-card';
 import { isTrpcClientError } from '@/src/trpc/common';
 import { trpcServer } from '@/src/trpc/trpc-server';
-import { ArrowRightIcon } from '@heroicons/react/16/solid';
-import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
-import { Link } from 'next-view-transitions';
-import { notFound } from 'next/navigation';
 
 type Props = {
 	params: Promise<{
@@ -29,7 +28,6 @@ async function Inner({ team }: { team: Pick<TeamSchema, 'slug' | 'displayName'> 
 	return <PasswordLoginCard team={team} />;
 }
 
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default async function TeamLoginPage(props: Props) {
 	const params = await props.params;
 	let displayName: string;

--- a/apps/web/src/app/team/join/[inviteCode]/layout.tsx
+++ b/apps/web/src/app/team/join/[inviteCode]/layout.tsx
@@ -1,7 +1,7 @@
+import type { PropsWithChildren } from 'react';
 import { Navbar } from '@/src/components/navbar/navbar';
 import { FooterWrapper } from '@/src/components/page-wrappers/footer-wrapper';
 import { MainContent } from '@/src/components/page-wrappers/main-content';
-import type { PropsWithChildren } from 'react';
 
 type Props = PropsWithChildren<{
 	params: Promise<{
@@ -9,7 +9,6 @@ type Props = PropsWithChildren<{
 	}>;
 }>;
 
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default function TeamInviteLayout({ children }: Props) {
 	return (
 		<FooterWrapper>

--- a/apps/web/src/app/team/join/[inviteCode]/page.tsx
+++ b/apps/web/src/app/team/join/[inviteCode]/page.tsx
@@ -6,7 +6,6 @@ type Props = {
 	}>;
 };
 
-// biome-ignore lint/style/noDefaultExport: This must be a default export
 export default async function TeamInvitePage(props: Props) {
 	const params = await props.params;
 	const inviteTeam = { inviteCode: params.inviteCode };

--- a/apps/web/src/components/account/login/login-card.tsx
+++ b/apps/web/src/components/account/login/login-card.tsx
@@ -1,15 +1,15 @@
 'use client';
 
-import { Button } from '@/components/ui/button';
-import { Card, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
-import { trpc } from '@/src/trpc/trpc-client';
 import { ArrowPathIcon } from '@heroicons/react/16/solid';
 import type { AuthenticationResponseJSON, PublicKeyCredentialRequestOptionsJSON } from '@simplewebauthn/browser';
-import { WebAuthnError, startAuthentication } from '@simplewebauthn/browser';
+import { startAuthentication, WebAuthnError } from '@simplewebauthn/browser';
 import { TRPCClientError } from '@trpc/client';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { Card, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { trpc } from '@/src/trpc/trpc-client';
 
 export function LoginCard() {
 	const router = useRouter();
@@ -45,7 +45,6 @@ export function LoginCard() {
 
 	const wrappedStartAuthentication = async (loginOptions: PublicKeyCredentialRequestOptionsJSON) => {
 		try {
-			// biome-ignore lint/style/useNamingConvention: This can't be renamed
 			return await startAuthentication({ optionsJSON: loginOptions });
 		} catch (error) {
 			if (error instanceof Error) {

--- a/apps/web/src/components/account/settings/delete-account-card.tsx
+++ b/apps/web/src/components/account/settings/delete-account-card.tsx
@@ -1,5 +1,8 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { toast } from 'sonner';
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -15,9 +18,6 @@ import { Button, buttonVariants } from '@/components/ui/button';
 import { Card, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { isTrpcClientError } from '@/src/trpc/common';
 import { trpc } from '@/src/trpc/trpc-client';
-import { useRouter } from 'next/navigation';
-import { useState } from 'react';
-import { toast } from 'sonner';
 
 export function DeleteAccountCard() {
 	const router = useRouter();

--- a/apps/web/src/components/account/settings/display-name-card/display-name-card.client.tsx
+++ b/apps/web/src/components/account/settings/display-name-card/display-name-card.client.tsx
@@ -1,10 +1,5 @@
 'use client';
 
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
-import { Form, FormControl, FormField, FormItem, FormMessage } from '@/components/ui/form';
-import { Input } from '@/components/ui/input';
-import { trpc } from '@/src/trpc/trpc-client';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { UserSchema } from '@interval.so/api/app/user/schemas/user_schema';
 import { useRouter } from 'next/navigation';
@@ -12,6 +7,11 @@ import { use, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import type { z } from 'zod';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { Form, FormControl, FormField, FormItem, FormMessage } from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { trpc } from '@/src/trpc/trpc-client';
 
 const formSchema = UserSchema.pick({ displayName: true });
 

--- a/apps/web/src/components/account/settings/display-name-card/display-name-card.server.tsx
+++ b/apps/web/src/components/account/settings/display-name-card/display-name-card.server.tsx
@@ -1,6 +1,6 @@
+import { Suspense } from 'react';
 import { SettingsCardSkeleton } from '@/src/components/settings-card-skeleton';
 import { trpcServer } from '@/src/trpc/trpc-server';
-import { Suspense } from 'react';
 import { DisplayNameCardInner } from './display-name-card.client';
 
 export function DisplayNameCard() {

--- a/apps/web/src/components/account/signup/signup-card.tsx
+++ b/apps/web/src/components/account/signup/signup-card.tsx
@@ -1,15 +1,10 @@
 'use client';
 
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
-import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
-import { Input } from '@/components/ui/input';
-import { trpc } from '@/src/trpc/trpc-client';
 import { ArrowPathIcon } from '@heroicons/react/16/solid';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { UserSchema } from '@interval.so/api/app/user/schemas/user_schema';
-import { WebAuthnError, startRegistration } from '@simplewebauthn/browser';
 import type { PublicKeyCredentialCreationOptionsJSON, RegistrationResponseJSON } from '@simplewebauthn/browser';
+import { startRegistration, WebAuthnError } from '@simplewebauthn/browser';
 import { TRPCClientError } from '@trpc/client';
 import { useRouter } from 'next/navigation';
 import { useQueryStates } from 'nuqs';
@@ -17,6 +12,11 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import type { z } from 'zod';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { trpc } from '@/src/trpc/trpc-client';
 import { searchParamParsers } from '../search-params';
 
 const formSchema = UserSchema.pick({ displayName: true });
@@ -73,7 +73,6 @@ export function SignupCard() {
 
 	const wrappedStartRegistration = async (registrationOptions: PublicKeyCredentialCreationOptionsJSON) => {
 		try {
-			// biome-ignore lint/style/useNamingConvention: This can't be renamed
 			return await startRegistration({ optionsJSON: registrationOptions });
 		} catch (error) {
 			if (error instanceof Error) {

--- a/apps/web/src/components/auth-wall/auth-wall.tsx
+++ b/apps/web/src/components/auth-wall/auth-wall.tsx
@@ -1,7 +1,7 @@
-import { trpcServer } from '@/src/trpc/trpc-server';
 import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import clsx from 'clsx';
 import type { PropsWithChildren } from 'react';
+import { trpcServer } from '@/src/trpc/trpc-server';
 import { MainContent } from '../page-wrappers/main-content';
 import { NeedsGuestOrManagerCard } from './needs-guest-or-manager-card';
 import { NeedsManagerAuthCard } from './needs-manager-auth-card';

--- a/apps/web/src/components/auth-wall/needs-guest-or-manager-card.tsx
+++ b/apps/web/src/components/auth-wall/needs-guest-or-manager-card.tsx
@@ -1,7 +1,7 @@
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import { Link } from 'next-view-transitions';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 
 export function NeedsGuestOrManagerCard({ team }: { team: Pick<TeamSchema, 'slug' | 'displayName'> }) {
 	return (

--- a/apps/web/src/components/auth-wall/needs-manager-auth-card.tsx
+++ b/apps/web/src/components/auth-wall/needs-manager-auth-card.tsx
@@ -1,7 +1,7 @@
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import { Link } from 'next-view-transitions';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 
 type Props = {
 	wantedTeam: Pick<TeamSchema, 'slug' | 'displayName'>;

--- a/apps/web/src/components/auth-wall/needs-manager-not-guest-card.tsx
+++ b/apps/web/src/components/auth-wall/needs-manager-not-guest-card.tsx
@@ -1,9 +1,9 @@
 'use client';
 
+import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { useLogOut } from '@/src/hooks/log-out';
-import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 
 type Props = {
 	wantedTeam: Pick<TeamSchema, 'slug' | 'displayName'>;

--- a/apps/web/src/components/auth-wall/needs-user-auth-card.tsx
+++ b/apps/web/src/components/auth-wall/needs-user-auth-card.tsx
@@ -1,6 +1,6 @@
+import { Link } from 'next-view-transitions';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
-import { Link } from 'next-view-transitions';
 
 export function NeedsUserAuthCard() {
 	return (

--- a/apps/web/src/components/auth-wall/not-guest-or-manager-card.tsx
+++ b/apps/web/src/components/auth-wall/not-guest-or-manager-card.tsx
@@ -1,9 +1,9 @@
 'use client';
 
+import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { useLogOut } from '@/src/hooks/log-out';
-import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 
 export function NotGuestOrManagerOfTeamCard({
 	user,

--- a/apps/web/src/components/auth-wall/not-manager-of-team-card.tsx
+++ b/apps/web/src/components/auth-wall/not-manager-of-team-card.tsx
@@ -1,10 +1,10 @@
 'use client';
 
+import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
+import type { UserSchema } from '@interval.so/api/app/user/schemas/user_schema';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { useLogOut } from '@/src/hooks/log-out';
-import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
-import type { UserSchema } from '@interval.so/api/app/user/schemas/user_schema';
 
 export function NotManagerOfTeamCard({
 	user,

--- a/apps/web/src/components/auth-wall/wrong-guest-team-card.tsx
+++ b/apps/web/src/components/auth-wall/wrong-guest-team-card.tsx
@@ -1,9 +1,9 @@
 'use client';
 
+import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { useLogOut } from '@/src/hooks/log-out';
-import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 
 type Props = {
 	currentTeam: Pick<TeamSchema, 'slug' | 'displayName'>;

--- a/apps/web/src/components/copy-button-input.tsx
+++ b/apps/web/src/components/copy-button-input.tsx
@@ -1,12 +1,12 @@
 'use client';
 
+import { CheckIcon, ClipboardIcon } from '@heroicons/react/16/solid';
+import clsx from 'clsx';
+import { AnimatePresence, motion, type Variants } from 'framer-motion';
+import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
-import { CheckIcon, ClipboardIcon } from '@heroicons/react/16/solid';
-import clsx from 'clsx';
-import { AnimatePresence, type Variants, motion } from 'framer-motion';
-import { useState } from 'react';
 import { ReadonlyTextField } from './readonly-text-field';
 
 type Props = {

--- a/apps/web/src/components/data-tables/faceted-filter.tsx
+++ b/apps/web/src/components/data-tables/faceted-filter.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { CheckIcon } from '@heroicons/react/16/solid';
+import type { Column } from '@tanstack/react-table';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -14,10 +16,7 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Separator } from '@/components/ui/separator';
 import { cn } from '@/lib/utils';
-import { CheckIcon } from '@heroicons/react/16/solid';
-import type { Column } from '@tanstack/react-table';
 
-// biome-ignore lint/style/useNamingConvention: This is PascalCase
 interface DataTableFacetedFilterProps<TData, TValue> {
 	column?: Column<TData, TValue>;
 	title?: string;
@@ -31,7 +30,6 @@ interface DataTableFacetedFilterProps<TData, TValue> {
 	className?: string;
 }
 
-// biome-ignore lint/style/useNamingConvention: This is PascalCase
 export function DataTableFacetedFilter<TData, TValue>({
 	column,
 	title,

--- a/apps/web/src/components/data-tables/sortable-header.tsx
+++ b/apps/web/src/components/data-tables/sortable-header.tsx
@@ -1,5 +1,10 @@
 'use client';
 
+import { ArrowDownIcon, ArrowUpIcon, ChevronUpDownIcon } from '@heroicons/react/16/solid';
+import type { Column } from '@tanstack/react-table';
+import clsx from 'clsx';
+import { AnimatePresence, motion, type Variants } from 'framer-motion';
+import type { PropsWithChildren } from 'react';
 import { Button } from '@/components/ui/button';
 import {
 	DropdownMenu,
@@ -7,11 +12,6 @@ import {
 	DropdownMenuItem,
 	DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { ArrowDownIcon, ArrowUpIcon, ChevronUpDownIcon } from '@heroicons/react/16/solid';
-import type { Column } from '@tanstack/react-table';
-import clsx from 'clsx';
-import { AnimatePresence, type Variants, motion } from 'framer-motion';
-import type { PropsWithChildren } from 'react';
 
 const motionVariants: Variants = {
 	hidden: {

--- a/apps/web/src/components/data-tables/table-pagination.tsx
+++ b/apps/web/src/components/data-tables/table-pagination.tsx
@@ -6,7 +6,6 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 
 // Adapted from https://ui.shadcn.com/docs/components/data-table#reusable-components
 
-// biome-ignore lint/style/useNamingConvention: This is in pascal case
 interface TablePaginationProps<TData> {
 	table: Table<TData>;
 	pageSizes?: readonly number[];
@@ -14,7 +13,6 @@ interface TablePaginationProps<TData> {
 
 const DEFAULT_PAGE_SIZES = [10, 25, 50] as const;
 
-// biome-ignore lint/style/useNamingConvention: This is in pascal case
 export function TablePagination<TData>({ table, pageSizes = DEFAULT_PAGE_SIZES }: TablePaginationProps<TData>) {
 	return (
 		<div className='flex items-center space-x-6 lg:space-x-8'>

--- a/apps/web/src/components/data-tables/table-selection-status.tsx
+++ b/apps/web/src/components/data-tables/table-selection-status.tsx
@@ -1,12 +1,10 @@
 import type { Table } from '@tanstack/react-table';
 import clsx from 'clsx';
 
-// biome-ignore lint/style/useNamingConvention: This is in pascal case
 type Props<TData> = {
 	table: Table<TData>;
 };
 
-// biome-ignore lint/style/useNamingConvention: This is in pascal case
 export function TableSelectionStatus<TData>({ table }: Props<TData>) {
 	return (
 		<div

--- a/apps/web/src/components/date-time-picker.tsx
+++ b/apps/web/src/components/date-time-picker.tsx
@@ -1,13 +1,13 @@
+import { CalendarIcon } from '@heroicons/react/16/solid';
+import { parseDate } from 'chrono-node';
+import { clamp } from 'date-fns';
+import { useState } from 'react';
 import { Button, type ButtonProps } from '@/components/ui/button';
 import { Calendar, type CalendarProps } from '@/components/ui/calendar';
 import { Input } from '@/components/ui/input';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Separator } from '@/components/ui/separator';
 import { cn } from '@/lib/utils';
-import { CalendarIcon } from '@heroicons/react/16/solid';
-import { parseDate } from 'chrono-node';
-import { clamp } from 'date-fns';
-import { useState } from 'react';
 import { formatDate } from '../utils/date-format';
 
 type Props = {

--- a/apps/web/src/components/date-time-range-picker.tsx
+++ b/apps/web/src/components/date-time-range-picker.tsx
@@ -1,15 +1,15 @@
 'use client';
 
+import { CalendarIcon } from '@heroicons/react/16/solid';
+import type { TimeRangeSchema } from '@interval.so/api/app/team_stats/schemas/time_range_schema';
+import { parseDate } from 'chrono-node';
+import { useEffect, useState } from 'react';
 import { Button, type ButtonProps } from '@/components/ui/button';
 import { Calendar, type CalendarProps } from '@/components/ui/calendar';
 import { Input } from '@/components/ui/input';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Separator } from '@/components/ui/separator';
 import { cn } from '@/lib/utils';
-import { CalendarIcon } from '@heroicons/react/16/solid';
-import type { TimeRangeSchema } from '@interval.so/api/app/team_stats/schemas/time_range_schema';
-import { parseDate } from 'chrono-node';
-import { useEffect, useState } from 'react';
 import { formatDate, formatDateRange } from '../utils/date-format';
 
 type Props = {

--- a/apps/web/src/components/date-time-range-picker.tsx
+++ b/apps/web/src/components/date-time-range-picker.tsx
@@ -3,7 +3,7 @@
 import { CalendarIcon } from '@heroicons/react/16/solid';
 import type { TimeRangeSchema } from '@interval.so/api/app/team_stats/schemas/time_range_schema';
 import { parseDate } from 'chrono-node';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Button, type ButtonProps } from '@/components/ui/button';
 import { Calendar, type CalendarProps } from '@/components/ui/calendar';
 import { Input } from '@/components/ui/input';
@@ -62,17 +62,7 @@ export function DateTimeRangePicker({
 	const [endInput, setEndInput] = useState(value.end ? formatDate(value.end) : '');
 	const now = new Date();
 
-	useEffect(() => {
-		// When value is updated externally (ex. reverting an invalid change), we trigger the calendar selection function
-		// This will update the text field values to ensure their state matches what is shown on the calendar
-
-		if (!(startInputFocused || endInputFocused)) {
-			// This is a hacky way to avoid the inputs effectively ignoring any changes that can't have a date extracted from them
-			onCalendarSelection(value);
-		}
-	}, [value, startInputFocused, endInputFocused]);
-
-	const onCalendarSelection = (range: Partial<TimeRangeSchema>) => {
+	const onCalendarSelection = useCallback((range: Partial<TimeRangeSchema>) => {
 		if (range.start) {
 			setStartInput(formatDate(range.start, true));
 		} else {
@@ -84,7 +74,17 @@ export function DateTimeRangePicker({
 		} else {
 			setEndInput('');
 		}
-	};
+	}, []);
+
+	useEffect(() => {
+		// When value is updated externally (ex. reverting an invalid change), we trigger the calendar selection function
+		// This will update the text field values to ensure their state matches what is shown on the calendar
+
+		if (!(startInputFocused || endInputFocused)) {
+			// This is a hacky way to avoid the inputs effectively ignoring any changes that can't have a date extracted from them
+			onCalendarSelection(value);
+		}
+	}, [value, startInputFocused, endInputFocused, onCalendarSelection]);
 
 	const onStartInput = (date: string) => {
 		setStartInput(date);

--- a/apps/web/src/components/dots/dots.module.css
+++ b/apps/web/src/components/dots/dots.module.css
@@ -4,10 +4,13 @@
 	/* SVG is used to get proper subpixel rendering, since radial gradients have a Chrome bug that prevents them from rendering properly */
 	/* They use the color of the `border` CSS variable (Radix Colors sand 6 for dark, and sand 8 for light). */
 	background-image: url("/dots/dot-light.svg"), url("/dots/dot-light.svg");
-	background-position: 15px 15px, 40px 40px;
+	background-position:
+		15px 15px,
+		40px 40px;
 	background-size: 50px 50px;
 }
 
+/* biome-ignore lint/correctness/noUnknownPseudoClass: This is valid CSS Modules syntax */
 .dots:global:where(.dark, .dark *) {
 	background-image: url("/dots/dot-dark.svg"), url("/dots/dot-dark.svg");
 }

--- a/apps/web/src/components/footer/theme-select.tsx
+++ b/apps/web/src/components/footer/theme-select.tsx
@@ -1,5 +1,9 @@
 'use client';
 
+import { ComputerDesktopIcon, MoonIcon, SunIcon } from '@heroicons/react/16/solid';
+import { AnimatePresence, motion, type Variants } from 'framer-motion';
+import { useTheme } from 'next-themes';
+import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import {
 	DropdownMenu,
@@ -9,10 +13,6 @@ import {
 	DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Skeleton } from '@/components/ui/skeleton';
-import { ComputerDesktopIcon, MoonIcon, SunIcon } from '@heroicons/react/16/solid';
-import { AnimatePresence, type Variants, motion } from 'framer-motion';
-import { useTheme } from 'next-themes';
-import { useEffect, useState } from 'react';
 
 const MotionSunIcon = motion.create(SunIcon);
 const MotionMoonIcon = motion.create(MoonIcon);

--- a/apps/web/src/components/graphs/custom-tooltip.tsx
+++ b/apps/web/src/components/graphs/custom-tooltip.tsx
@@ -1,6 +1,6 @@
-import { Card, CardTitle } from '@/components/ui/card';
 import { DatumPeriod } from '@interval.so/api/app/team_stats/schemas/datum_time_range_schema';
 import type { ReactNode } from 'react';
+import { Card, CardTitle } from '@/components/ui/card';
 
 export function formatTooltipDate(date: Date, period: DatumPeriod): string {
 	const now = new Date();

--- a/apps/web/src/components/graphs/graph-utils.ts
+++ b/apps/web/src/components/graphs/graph-utils.ts
@@ -1,6 +1,5 @@
 import { DatumPeriod } from '@interval.so/api/app/team_stats/schemas/datum_time_range_schema';
 
-// biome-ignore lint/style/useNamingConvention: This is camelcase
 export function formatXAxisDate(date: Date, period: DatumPeriod): string {
 	const now = new Date();
 	const options: Intl.DateTimeFormatOptions = {

--- a/apps/web/src/components/home/create-team-card.tsx
+++ b/apps/web/src/components/home/create-team-card.tsx
@@ -1,6 +1,6 @@
-import { Card, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { PlusIcon } from '@heroicons/react/24/solid';
 import { Link } from 'next-view-transitions';
+import { Card, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 
 export function CreateTeamCard() {
 	return (

--- a/apps/web/src/components/home/team-card/team-card.client.tsx
+++ b/apps/web/src/components/home/team-card/team-card.client.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { trpc } from '@/src/trpc/trpc-client';
 import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import { count } from '@jonahsnider/util';
 import { use, useState } from 'react';
+import { trpc } from '@/src/trpc/trpc-client';
 
 type Props = {
 	team: Pick<TeamSchema, 'slug'>;

--- a/apps/web/src/components/home/team-card/team-card.server.tsx
+++ b/apps/web/src/components/home/team-card/team-card.server.tsx
@@ -1,11 +1,11 @@
-import { Card, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
-import { Skeleton } from '@/components/ui/skeleton';
-import { trpcServer } from '@/src/trpc/trpc-server';
 import { ArrowRightIcon } from '@heroicons/react/24/solid';
 import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import { count } from '@jonahsnider/util';
 import { Link } from 'next-view-transitions';
 import { Suspense } from 'react';
+import { Card, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { trpcServer } from '@/src/trpc/trpc-server';
 import { MemberAvatars } from '../../team-dashboard/member-avatars/member-avatars.server';
 import { TeamCardDescription } from './team-card.client';
 

--- a/apps/web/src/components/home/team-cards.tsx
+++ b/apps/web/src/components/home/team-cards.tsx
@@ -1,8 +1,8 @@
+import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
+import { Suspense, use } from 'react';
 import { Card, CardFooter, CardHeader } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { trpcServer } from '@/src/trpc/trpc-server';
-import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
-import { Suspense, use } from 'react';
 import { CreateTeamCard } from './create-team-card';
 import { TeamCard } from './team-card/team-card.server';
 
@@ -43,11 +43,7 @@ function TeamCardSkeleton() {
 	);
 }
 
-function TeamCardsInner({
-	teamsPromise,
-}: {
-	teamsPromise: Promise<Pick<TeamSchema, 'displayName' | 'slug'>[]>;
-}) {
+function TeamCardsInner({ teamsPromise }: { teamsPromise: Promise<Pick<TeamSchema, 'displayName' | 'slug'>[]> }) {
 	const teams = use(teamsPromise);
 
 	return (

--- a/apps/web/src/components/landing/cta/cta.module.css
+++ b/apps/web/src/components/landing/cta/cta.module.css
@@ -1,5 +1,9 @@
 .cta {
 	background-image: url("/home/cta/text-segment.svg"), url("/home/cta/text-segment.svg");
-	background-size: 127px 64px, 127px 64px;
-	background-position: 0px 0px, 63px 32px;
+	background-size:
+		127px 64px,
+		127px 64px;
+	background-position:
+		0px 0px,
+		63px 32px;
 }

--- a/apps/web/src/components/landing/cta/landing-cta-section.tsx
+++ b/apps/web/src/components/landing/cta/landing-cta-section.tsx
@@ -1,6 +1,6 @@
-import { buttonVariants } from '@/components/ui/button';
 import clsx from 'clsx';
 import { Link } from 'next-view-transitions';
+import { buttonVariants } from '@/components/ui/button';
 import styles from './cta.module.css';
 
 export function LandingCtaSection() {

--- a/apps/web/src/components/manager/dashboard/graphs/average-hours-graph/average-hours-graph.client.tsx
+++ b/apps/web/src/components/manager/dashboard/graphs/average-hours-graph/average-hours-graph.client.tsx
@@ -1,5 +1,12 @@
 'use client';
 
+import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
+import type { AverageHoursDatumSchema } from '@interval.so/api/app/team_stats/schemas/average_hours_datum_schema';
+import type { DatumPeriod } from '@interval.so/api/app/team_stats/schemas/datum_time_range_schema';
+import { toDigits } from '@jonahsnider/util';
+import { useQueryStates } from 'nuqs';
+import { use, useMemo, useState } from 'react';
+import { Area, AreaChart, CartesianGrid, type TooltipProps, XAxis, YAxis } from 'recharts';
 import { type ChartConfig, ChartContainer, ChartTooltip } from '@/components/ui/chart';
 import {
 	areaChartProps,
@@ -12,13 +19,6 @@ import {
 import { CustomTooltip, formatTooltipDate } from '@/src/components/graphs/custom-tooltip';
 import { formatXAxisDate } from '@/src/components/graphs/graph-utils';
 import { trpc } from '@/src/trpc/trpc-client';
-import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
-import type { AverageHoursDatumSchema } from '@interval.so/api/app/team_stats/schemas/average_hours_datum_schema';
-import type { DatumPeriod } from '@interval.so/api/app/team_stats/schemas/datum_time_range_schema';
-import { toDigits } from '@jonahsnider/util';
-import { useQueryStates } from 'nuqs';
-import { use, useMemo, useState } from 'react';
-import { Area, AreaChart, CartesianGrid, type TooltipProps, XAxis, YAxis } from 'recharts';
 import { toTimeFilter } from '../../../period-select/duration-slug';
 import { searchParamParsers } from '../../search-params';
 
@@ -40,13 +40,7 @@ const chartConfig = {
 	},
 } satisfies ChartConfig;
 
-function HoursTooltip({
-	period,
-	tooltipProps,
-}: {
-	tooltipProps: TooltipProps<number, string>;
-	period: DatumPeriod;
-}) {
+function HoursTooltip({ period, tooltipProps }: { tooltipProps: TooltipProps<number, string>; period: DatumPeriod }) {
 	const entry = tooltipProps.payload?.[0];
 
 	if (!entry) {

--- a/apps/web/src/components/manager/dashboard/graphs/average-hours-graph/average-hours-graph.server.tsx
+++ b/apps/web/src/components/manager/dashboard/graphs/average-hours-graph/average-hours-graph.server.tsx
@@ -1,8 +1,8 @@
-import { trpcServer } from '@/src/trpc/trpc-server';
 import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import { timeFilterToDatumPeriod } from '@interval.so/api/app/team_stats/schemas/datum_time_range_schema';
 import type { TimeFilterSchema } from '@interval.so/api/app/team_stats/schemas/time_filter_schema';
 import { Suspense } from 'react';
+import { trpcServer } from '@/src/trpc/trpc-server';
 import { AverageHoursGraphClient } from './average-hours-graph.client';
 
 type Props = {

--- a/apps/web/src/components/manager/dashboard/graphs/tabs/graph-tab-trigger.tsx
+++ b/apps/web/src/components/manager/dashboard/graphs/tabs/graph-tab-trigger.tsx
@@ -1,8 +1,5 @@
 import 'server-only';
 
-import { Badge } from '@/components/ui/badge';
-import { Skeleton } from '@/components/ui/skeleton';
-import { trpcServer } from '@/src/trpc/trpc-server';
 import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import type { TimeFilterSchema } from '@interval.so/api/app/team_stats/schemas/time_filter_schema';
 import type { TimeRangeSchema } from '@interval.so/api/app/team_stats/schemas/time_range_schema';
@@ -10,6 +7,9 @@ import { toDigits } from '@jonahsnider/util';
 import clsx from 'clsx';
 import { Link } from 'next-view-transitions';
 import { type ReactNode, Suspense } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { trpcServer } from '@/src/trpc/trpc-server';
 import { searchParamCache, searchParamSerializer } from '../../search-params';
 
 type TabId = 'members' | 'hours';

--- a/apps/web/src/components/manager/dashboard/graphs/tabs/graph-tabs.tsx
+++ b/apps/web/src/components/manager/dashboard/graphs/tabs/graph-tabs.tsx
@@ -1,8 +1,8 @@
 import 'server-only';
 
-import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import { ErrorBoundary } from 'react-error-boundary';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { toTimeFilter, toTimeRange } from '../../../period-select/duration-slug';
 import { searchParamCache } from '../../search-params';
 import { AverageHoursGraph } from '../average-hours-graph/average-hours-graph.server';

--- a/apps/web/src/components/manager/dashboard/graphs/unique-members-graph/unique-members-graph.client.tsx
+++ b/apps/web/src/components/manager/dashboard/graphs/unique-members-graph/unique-members-graph.client.tsx
@@ -1,5 +1,12 @@
 'use client';
 
+import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
+import type { DatumPeriod } from '@interval.so/api/app/team_stats/schemas/datum_time_range_schema';
+import type { UniqueMembersDatumSchema } from '@interval.so/api/app/team_stats/schemas/unique_members_datum_schema';
+import { max } from '@jonahsnider/util';
+import { useQueryStates } from 'nuqs';
+import { use, useMemo, useState } from 'react';
+import { Area, AreaChart, CartesianGrid, type TooltipProps, XAxis, YAxis } from 'recharts';
 import { type ChartConfig, ChartContainer, ChartTooltip } from '@/components/ui/chart';
 import {
 	areaChartProps,
@@ -12,13 +19,6 @@ import {
 import { CustomTooltip, formatTooltipDate } from '@/src/components/graphs/custom-tooltip';
 import { formatXAxisDate } from '@/src/components/graphs/graph-utils';
 import { trpc } from '@/src/trpc/trpc-client';
-import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
-import type { DatumPeriod } from '@interval.so/api/app/team_stats/schemas/datum_time_range_schema';
-import type { UniqueMembersDatumSchema } from '@interval.so/api/app/team_stats/schemas/unique_members_datum_schema';
-import { max } from '@jonahsnider/util';
-import { useQueryStates } from 'nuqs';
-import { use, useMemo, useState } from 'react';
-import { Area, AreaChart, CartesianGrid, type TooltipProps, XAxis, YAxis } from 'recharts';
 import { toTimeFilter } from '../../../period-select/duration-slug';
 import { searchParamParsers } from '../../search-params';
 
@@ -41,13 +41,7 @@ const chartConfig = {
 	},
 } satisfies ChartConfig;
 
-function MembersTooltip({
-	period,
-	tooltipProps,
-}: {
-	tooltipProps: TooltipProps<number, string>;
-	period: DatumPeriod;
-}) {
+function MembersTooltip({ period, tooltipProps }: { tooltipProps: TooltipProps<number, string>; period: DatumPeriod }) {
 	const entry = tooltipProps.payload?.[0];
 
 	if (!entry) {

--- a/apps/web/src/components/manager/dashboard/graphs/unique-members-graph/unique-members-graph.server.tsx
+++ b/apps/web/src/components/manager/dashboard/graphs/unique-members-graph/unique-members-graph.server.tsx
@@ -1,8 +1,8 @@
-import { trpcServer } from '@/src/trpc/trpc-server';
 import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import { timeFilterToDatumPeriod } from '@interval.so/api/app/team_stats/schemas/datum_time_range_schema';
 import type { TimeFilterSchema } from '@interval.so/api/app/team_stats/schemas/time_filter_schema';
 import { Suspense } from 'react';
+import { trpcServer } from '@/src/trpc/trpc-server';
 import { UniqueMembersGraphClient } from './unique-members-graph.client';
 
 type Props = {

--- a/apps/web/src/components/manager/dashboard/manager-dashboard-context.tsx
+++ b/apps/web/src/components/manager/dashboard/manager-dashboard-context.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useQueryStates } from 'nuqs';
-import { type PropsWithChildren, createContext, useMemo } from 'react';
+import { createContext, type PropsWithChildren, useMemo } from 'react';
 import type { SelectRangeEventHandler } from 'react-day-picker';
 import { DurationSlug } from '../period-select/duration-slug';
 import { searchParamParsers } from './search-params';

--- a/apps/web/src/components/manager/dashboard/tiles/combined-hours-tile/combined-hours-tile.client.tsx
+++ b/apps/web/src/components/manager/dashboard/tiles/combined-hours-tile/combined-hours-tile.client.tsx
@@ -1,10 +1,10 @@
 'use client';
-import type { RouterOutput } from '@/src/trpc/common';
-import { trpc } from '@/src/trpc/trpc-client';
 import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import type { TimeRangeSchema } from '@interval.so/api/app/team_stats/schemas/time_range_schema';
 import { useQueryStates } from 'nuqs';
 import { useMemo, useState } from 'react';
+import type { RouterOutput } from '@/src/trpc/common';
+import { trpc } from '@/src/trpc/trpc-client';
 import {
 	type DurationSlug,
 	durationLabelPreviousPeriod,

--- a/apps/web/src/components/manager/dashboard/tiles/combined-hours-tile/combined-hours-tile.server.tsx
+++ b/apps/web/src/components/manager/dashboard/tiles/combined-hours-tile/combined-hours-tile.server.tsx
@@ -1,10 +1,10 @@
-import { Skeleton } from '@/components/ui/skeleton';
-import { trpcServer } from '@/src/trpc/trpc-server';
 import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import type { TimeFilterSchema } from '@interval.so/api/app/team_stats/schemas/time_filter_schema';
 import type { TimeRangeSchema } from '@interval.so/api/app/team_stats/schemas/time_range_schema';
 import { Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
+import { Skeleton } from '@/components/ui/skeleton';
+import { trpcServer } from '@/src/trpc/trpc-server';
 import type { DurationSlug } from '../../../period-select/duration-slug';
 import { CombinedHoursTileClient } from './combined-hours-tile.client';
 import { CombinedHoursTileBase } from './combined-hours-tile.shared';

--- a/apps/web/src/components/manager/dashboard/tiles/combined-hours-tile/combined-hours-tile.shared.tsx
+++ b/apps/web/src/components/manager/dashboard/tiles/combined-hours-tile/combined-hours-tile.shared.tsx
@@ -1,6 +1,6 @@
-import { Card, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import clsx from 'clsx';
 import type { ReactNode } from 'react';
+import { Card, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 
 export function CombinedHoursTileBase({ trend, value }: { trend?: ReactNode; value: ReactNode }) {
 	return (

--- a/apps/web/src/components/manager/dashboard/tiles/live-member-count-tile/live-member-count-tile.client.tsx
+++ b/apps/web/src/components/manager/dashboard/tiles/live-member-count-tile/live-member-count-tile.client.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { Progress } from '@/components/ui/progress';
-import { trpc } from '@/src/trpc/trpc-client';
 import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import type { SimpleTeamMemberSchema } from '@interval.so/api/app/team_member/schemas/team_member_schema';
 import { count } from '@jonahsnider/util';
 import { useState } from 'react';
+import { Progress } from '@/components/ui/progress';
+import { trpc } from '@/src/trpc/trpc-client';
 import { LiveMemberCountTileBase } from './live-member-count-tile.shared';
 
 type Props = {

--- a/apps/web/src/components/manager/dashboard/tiles/live-member-count-tile/live-member-count-tile.server.tsx
+++ b/apps/web/src/components/manager/dashboard/tiles/live-member-count-tile/live-member-count-tile.server.tsx
@@ -1,7 +1,7 @@
-import { Skeleton } from '@/components/ui/skeleton';
-import { trpcServer } from '@/src/trpc/trpc-server';
 import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import { Suspense } from 'react';
+import { Skeleton } from '@/components/ui/skeleton';
+import { trpcServer } from '@/src/trpc/trpc-server';
 import { LiveMemberCountTileClient } from './live-member-count-tile.client';
 import { LiveMemberCountTileBase } from './live-member-count-tile.shared';
 

--- a/apps/web/src/components/manager/dashboard/tiles/live-member-count-tile/live-member-count-tile.shared.tsx
+++ b/apps/web/src/components/manager/dashboard/tiles/live-member-count-tile/live-member-count-tile.shared.tsx
@@ -1,6 +1,6 @@
+import type { ReactNode } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
-import type { ReactNode } from 'react';
 
 export function LiveMemberCountTileBase({ progressBar, value }: { progressBar: ReactNode; value: ReactNode }) {
 	return (

--- a/apps/web/src/components/manager/end-meeting-alert.tsx
+++ b/apps/web/src/components/manager/end-meeting-alert.tsx
@@ -1,4 +1,9 @@
 'use client';
+import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
+import clsx from 'clsx';
+import type { PropsWithChildren } from 'react';
+import { useState } from 'react';
+import { toast } from 'sonner';
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -13,11 +18,6 @@ import {
 import { buttonVariants } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { trpc } from '@/src/trpc/trpc-client';
-import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
-import clsx from 'clsx';
-import type { PropsWithChildren } from 'react';
-import { useState } from 'react';
-import { toast } from 'sonner';
 import { DateTimePicker } from '../date-time-picker';
 
 type Props = PropsWithChildren<{
@@ -94,13 +94,7 @@ function EndMeetingAlertContent({
 	);
 }
 
-function EndMeetingDialogAction({
-	date,
-	team,
-}: {
-	date?: Date;
-	team: Pick<TeamSchema, 'slug'>;
-}) {
+function EndMeetingDialogAction({ date, team }: { date?: Date; team: Pick<TeamSchema, 'slug'> }) {
 	const [toastId, setToastId] = useState<string | number | undefined>();
 
 	const signOutAll = trpc.teams.members.endMeeting.useMutation({

--- a/apps/web/src/components/manager/end-meeting-button/end-meeting-button.client.tsx
+++ b/apps/web/src/components/manager/end-meeting-button/end-meeting-button.client.tsx
@@ -1,11 +1,11 @@
 'use client';
-import { Button } from '@/components/ui/button';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
-import { trpc } from '@/src/trpc/trpc-client';
 import { ArrowRightStartOnRectangleIcon } from '@heroicons/react/16/solid';
 import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import clsx from 'clsx';
 import { use, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { trpc } from '@/src/trpc/trpc-client';
 import { EndMeetingAlert, EndMeetingAlertTrigger } from '../end-meeting-alert';
 
 type Props = {

--- a/apps/web/src/components/manager/end-meeting-button/end-meeting-button.tsx
+++ b/apps/web/src/components/manager/end-meeting-button/end-meeting-button.tsx
@@ -1,8 +1,8 @@
-import { Skeleton } from '@/components/ui/skeleton';
-import { trpcServer } from '@/src/trpc/trpc-server';
 import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import clsx from 'clsx';
 import { Suspense } from 'react';
+import { Skeleton } from '@/components/ui/skeleton';
+import { trpcServer } from '@/src/trpc/trpc-server';
 import { EndMeetingButtonClient } from './end-meeting-button.client';
 
 type Props = {

--- a/apps/web/src/components/manager/meetings/create-meeting-dialog/attendees-select.tsx
+++ b/apps/web/src/components/manager/meetings/create-meeting-dialog/attendees-select.tsx
@@ -1,3 +1,8 @@
+import { CheckIcon, UsersIcon } from '@heroicons/react/16/solid';
+import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
+import type { TeamMemberSchema } from '@interval.so/api/app/team_member/schemas/team_member_schema';
+import clsx from 'clsx';
+import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import {
 	Command,
@@ -10,11 +15,6 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Separator } from '@/components/ui/separator';
 import { trpc } from '@/src/trpc/trpc-client';
-import { CheckIcon, UsersIcon } from '@heroicons/react/16/solid';
-import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
-import type { TeamMemberSchema } from '@interval.so/api/app/team_member/schemas/team_member_schema';
-import clsx from 'clsx';
-import { useState } from 'react';
 
 type Props = {
 	team: Pick<TeamSchema, 'slug'>;

--- a/apps/web/src/components/manager/meetings/create-meeting-dialog/create-meeting-dialog.tsx
+++ b/apps/web/src/components/manager/meetings/create-meeting-dialog/create-meeting-dialog.tsx
@@ -1,9 +1,5 @@
 'use client';
 
-import { Button } from '@/components/ui/button';
-import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
-import { trpc } from '@/src/trpc/trpc-client';
 import { PlusIcon } from '@heroicons/react/16/solid';
 import { zodResolver } from '@hookform/resolvers/zod';
 import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
@@ -13,6 +9,10 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import type { z } from 'zod';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
+import { trpc } from '@/src/trpc/trpc-client';
 import { DateTimeRangePicker } from '../../../date-time-range-picker';
 import { AttendeesSelect } from './attendees-select';
 

--- a/apps/web/src/components/manager/meetings/download-meetings-csv-button.tsx
+++ b/apps/web/src/components/manager/meetings/download-meetings-csv-button.tsx
@@ -1,14 +1,14 @@
 'use client';
 
-import { Button } from '@/components/ui/button';
-import { trpc } from '@/src/trpc/trpc-client';
-import { formatDate } from '@/src/utils/date-format';
 import { ArrowDownTrayIcon } from '@heroicons/react/16/solid';
 import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import type { TeamMeetingSchema } from '@interval.so/api/app/team_meeting/schemas/team_meeting_schema';
 import { multiReplace } from '@jonahsnider/util';
 import { useQueryStates } from 'nuqs';
 import { useMemo } from 'react';
+import { Button } from '@/components/ui/button';
+import { trpc } from '@/src/trpc/trpc-client';
+import { formatDate } from '@/src/utils/date-format';
 import { toTimeFilter } from '../period-select/duration-slug';
 import { searchParamParsers } from './search-params';
 

--- a/apps/web/src/components/manager/meetings/meeting-dialog/meeting-attendee-table/columns.tsx
+++ b/apps/web/src/components/manager/meetings/meeting-dialog/meeting-attendee-table/columns.tsx
@@ -1,15 +1,15 @@
 'use client';
-import { buttonVariants } from '@/components/ui/button';
-import { cn } from '@/lib/utils';
-import { SortableHeader } from '@/src/components/data-tables/sortable-header';
-import { TeamSlugContext } from '@/src/components/team-dashboard/team-slug-provider';
-import { formatDuration } from '@/src/utils/date-format';
 import type { AttendanceEntrySchema } from '@interval.so/api/app/team_member_attendance/schemas/attendance_entry_schema';
 import { Sort } from '@jonahsnider/util';
 import type { ColumnDef } from '@tanstack/react-table';
 import { type Duration, intervalToDuration, milliseconds } from 'date-fns';
 import Link from 'next/link';
 import { useContext } from 'react';
+import { buttonVariants } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { SortableHeader } from '@/src/components/data-tables/sortable-header';
+import { TeamSlugContext } from '@/src/components/team-dashboard/team-slug-provider';
+import { formatDuration } from '@/src/utils/date-format';
 import { MeetingDateRangePicker } from '../../../members/view-member/member-attendance-section/meeting-date-range-picker';
 import { RowActionsDropdown } from './row-actions-dropdown';
 

--- a/apps/web/src/components/manager/meetings/meeting-dialog/meeting-attendee-table/meeting-attendee-table.tsx
+++ b/apps/web/src/components/manager/meetings/meeting-dialog/meeting-attendee-table/meeting-attendee-table.tsx
@@ -1,15 +1,15 @@
 'use client';
 
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import type { TeamMeetingSchema } from '@interval.so/api/app/team_meeting/schemas/team_meeting_schema';
 import {
-	type SortingState,
 	flexRender,
 	getCoreRowModel,
 	getSortedRowModel,
+	type SortingState,
 	useReactTable,
 } from '@tanstack/react-table';
 import { useState } from 'react';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { columns } from './columns';
 
 type Props = {

--- a/apps/web/src/components/manager/meetings/meeting-dialog/meeting-attendee-table/row-actions-dropdown.tsx
+++ b/apps/web/src/components/manager/meetings/meeting-dialog/meeting-attendee-table/row-actions-dropdown.tsx
@@ -1,5 +1,9 @@
 'use client';
 
+import { EllipsisVerticalIcon, TrashIcon } from '@heroicons/react/16/solid';
+import type { AttendanceEntrySchema } from '@interval.so/api/app/team_member_attendance/schemas/attendance_entry_schema';
+import { useState } from 'react';
+import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import {
 	DropdownMenu,
@@ -8,10 +12,6 @@ import {
 	DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { trpc } from '@/src/trpc/trpc-client';
-import { EllipsisVerticalIcon, TrashIcon } from '@heroicons/react/16/solid';
-import type { AttendanceEntrySchema } from '@interval.so/api/app/team_member_attendance/schemas/attendance_entry_schema';
-import { useState } from 'react';
-import { toast } from 'sonner';
 
 type Props = {
 	attendanceEntry: Pick<AttendanceEntrySchema, 'attendanceId' | 'member'>;

--- a/apps/web/src/components/manager/meetings/meeting-dialog/meeting-dialog-actions.tsx
+++ b/apps/web/src/components/manager/meetings/meeting-dialog/meeting-dialog-actions.tsx
@@ -1,3 +1,8 @@
+import { EllipsisVerticalIcon, TrashIcon } from '@heroicons/react/16/solid';
+import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
+import type { TeamMeetingSchema } from '@interval.so/api/app/team_meeting/schemas/team_meeting_schema';
+import { useState } from 'react';
+import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import {
 	DropdownMenu,
@@ -6,11 +11,6 @@ import {
 	DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { trpc } from '@/src/trpc/trpc-client';
-import { EllipsisVerticalIcon, TrashIcon } from '@heroicons/react/16/solid';
-import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
-import type { TeamMeetingSchema } from '@interval.so/api/app/team_meeting/schemas/team_meeting_schema';
-import { useState } from 'react';
-import { toast } from 'sonner';
 
 type Props = {
 	meeting: TeamMeetingSchema;

--- a/apps/web/src/components/manager/meetings/meeting-dialog/meeting-dialog-changes-context.tsx
+++ b/apps/web/src/components/manager/meetings/meeting-dialog/meeting-dialog-changes-context.tsx
@@ -28,7 +28,6 @@ export function MeetingDialogChangesProvider({ children }: { children: React.Rea
 
 	const updateMeeting = useMemo(
 		() => (original: Pick<AttendanceEntrySchema, 'attendanceId' | 'startedAt' | 'endedAt'>, data: MeetingChange) => {
-			// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: No obvious way to simplify this
 			setUpdatedMeetings((draft) => {
 				draft.meetings[original.attendanceId] ??= {
 					startedAt: original.startedAt,

--- a/apps/web/src/components/manager/meetings/meeting-dialog/meeting-dialog-content.tsx
+++ b/apps/web/src/components/manager/meetings/meeting-dialog/meeting-dialog-content.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
+import type { TeamMeetingSchema } from '@interval.so/api/app/team_meeting/schemas/team_meeting_schema';
 import { Button } from '@/components/ui/button';
 import {
 	DialogClose,
@@ -11,8 +13,6 @@ import {
 } from '@/components/ui/dialog';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { formatDateRange } from '@/src/utils/date-format';
-import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
-import type { TeamMeetingSchema } from '@interval.so/api/app/team_meeting/schemas/team_meeting_schema';
 import { MeetingAttendeeTable } from './meeting-attendee-table/meeting-attendee-table';
 import { MeetingDialogActions } from './meeting-dialog-actions';
 

--- a/apps/web/src/components/manager/meetings/meeting-dialog/meeting-dialog.tsx
+++ b/apps/web/src/components/manager/meetings/meeting-dialog/meeting-dialog.tsx
@@ -1,8 +1,8 @@
-import { Dialog, DialogTrigger } from '@/components/ui/dialog';
 import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import type { TeamMeetingSchema } from '@interval.so/api/app/team_meeting/schemas/team_meeting_schema';
 import { useQueryStates } from 'nuqs';
 import { type PropsWithChildren, useContext } from 'react';
+import { Dialog, DialogTrigger } from '@/components/ui/dialog';
 import { searchParamParsers } from '../search-params';
 import { MeetingDialogChangesContext, MeetingDialogChangesProvider } from './meeting-dialog-changes-context';
 import { MeetingDialogContent } from './meeting-dialog-content';

--- a/apps/web/src/components/manager/meetings/meetings-table/columns.tsx
+++ b/apps/web/src/components/manager/meetings/meetings-table/columns.tsx
@@ -1,16 +1,16 @@
 'use client';
 
+import type { TeamMeetingSchema } from '@interval.so/api/app/team_meeting/schemas/team_meeting_schema';
+import { Sort } from '@jonahsnider/util';
+import type { ColumnDef } from '@tanstack/react-table';
+import { type Duration, intervalToDuration, milliseconds } from 'date-fns';
+import { type PropsWithChildren, useContext } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { SortableHeader } from '@/src/components/data-tables/sortable-header';
 import { TeamSlugContext } from '@/src/components/team-dashboard/team-slug-provider';
 import { formatDate, formatDateRange, formatDuration } from '@/src/utils/date-format';
-import type { TeamMeetingSchema } from '@interval.so/api/app/team_meeting/schemas/team_meeting_schema';
-import { Sort } from '@jonahsnider/util';
-import type { ColumnDef } from '@tanstack/react-table';
-import { type Duration, intervalToDuration, milliseconds } from 'date-fns';
-import { type PropsWithChildren, useContext } from 'react';
 import { MeetingDialog } from '../meeting-dialog/meeting-dialog';
 import { RowActionsDropdown } from './row-actions/row-actions-dropdown';
 

--- a/apps/web/src/components/manager/meetings/meetings-table/meetings-table.client.tsx
+++ b/apps/web/src/components/manager/meetings/meetings-table/meetings-table.client.tsx
@@ -1,22 +1,22 @@
 'use client';
 
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
-import { TablePagination } from '@/src/components/data-tables/table-pagination';
-import { trpc } from '@/src/trpc/trpc-client';
 import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import type { TeamMeetingSchema } from '@interval.so/api/app/team_meeting/schemas/team_meeting_schema';
 import {
-	type PaginationState,
-	type SortingState,
 	flexRender,
 	getCoreRowModel,
 	getPaginationRowModel,
 	getSortedRowModel,
+	type PaginationState,
+	type SortingState,
 	useReactTable,
 } from '@tanstack/react-table';
 import clsx from 'clsx';
 import { useQueryStates } from 'nuqs';
 import { use, useMemo, useState } from 'react';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { TablePagination } from '@/src/components/data-tables/table-pagination';
+import { trpc } from '@/src/trpc/trpc-client';
 import { toTimeFilter } from '../../period-select/duration-slug';
 import { searchParamParsers } from '../search-params';
 import { columns } from './columns';

--- a/apps/web/src/components/manager/meetings/meetings-table/meetings-table.tsx
+++ b/apps/web/src/components/manager/meetings/meetings-table/meetings-table.tsx
@@ -1,14 +1,14 @@
 import 'server-only';
 
-import { Skeleton } from '@/components/ui/skeleton';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
-import { trpcServer } from '@/src/trpc/trpc-server';
 import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import type { TimeFilterSchema } from '@interval.so/api/app/team_stats/schemas/time_filter_schema';
 import { Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
-import { InnerTableContainer, OuterTableContainer } from './meetings-table-common';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { trpcServer } from '@/src/trpc/trpc-server';
 import { MeetingsTableClient } from './meetings-table.client';
+import { InnerTableContainer, OuterTableContainer } from './meetings-table-common';
 
 type Props = {
 	team: Pick<TeamSchema, 'slug'>;

--- a/apps/web/src/components/manager/meetings/meetings-table/row-actions/delete-meeting-item.tsx
+++ b/apps/web/src/components/manager/meetings/meetings-table/row-actions/delete-meeting-item.tsx
@@ -1,5 +1,10 @@
 'use client';
 
+import { TrashIcon } from '@heroicons/react/16/solid';
+import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
+import type { TeamMeetingSchema } from '@interval.so/api/app/team_meeting/schemas/team_meeting_schema';
+import { useState } from 'react';
+import { toast } from 'sonner';
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -14,11 +19,6 @@ import {
 import { buttonVariants } from '@/components/ui/button';
 import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
 import { trpc } from '@/src/trpc/trpc-client';
-import { TrashIcon } from '@heroicons/react/16/solid';
-import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
-import type { TeamMeetingSchema } from '@interval.so/api/app/team_meeting/schemas/team_meeting_schema';
-import { useState } from 'react';
-import { toast } from 'sonner';
 
 type Props = {
 	team: Pick<TeamSchema, 'slug'>;

--- a/apps/web/src/components/manager/meetings/meetings-table/row-actions/end-meeting-item.tsx
+++ b/apps/web/src/components/manager/meetings/meetings-table/row-actions/end-meeting-item.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
 import { ArrowRightStartOnRectangleIcon } from '@heroicons/react/16/solid';
+import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
 
 type Props = {
 	setDialogOpen: (open: boolean) => void;

--- a/apps/web/src/components/manager/meetings/meetings-table/row-actions/row-actions-dropdown.tsx
+++ b/apps/web/src/components/manager/meetings/meetings-table/row-actions/row-actions-dropdown.tsx
@@ -1,5 +1,9 @@
 'use client';
 
+import { EllipsisVerticalIcon } from '@heroicons/react/16/solid';
+import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
+import type { TeamMeetingSchema } from '@interval.so/api/app/team_meeting/schemas/team_meeting_schema';
+import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import {
 	DropdownMenu,
@@ -7,10 +11,6 @@ import {
 	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { EllipsisVerticalIcon } from '@heroicons/react/16/solid';
-import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
-import type { TeamMeetingSchema } from '@interval.so/api/app/team_meeting/schemas/team_meeting_schema';
-import { useState } from 'react';
 import { EndMeetingAlert } from '../../../end-meeting-alert';
 import { DeleteMeetingItem } from './delete-meeting-item';
 import { EndMeetingItem } from './end-meeting-item';

--- a/apps/web/src/components/manager/members/members-table/batch-actions/batch-actions-dropdown.tsx
+++ b/apps/web/src/components/manager/members/members-table/batch-actions/batch-actions-dropdown.tsx
@@ -1,5 +1,9 @@
 'use client';
 
+import { EllipsisVerticalIcon } from '@heroicons/react/16/solid';
+import type { TeamMemberSchema } from '@interval.so/api/app/team_member/schemas/team_member_schema';
+import type { Table } from '@tanstack/react-table';
+import { useState } from 'react';
 import { AlertDialog } from '@/components/ui/alert-dialog';
 import { Button } from '@/components/ui/button';
 import {
@@ -8,10 +12,6 @@ import {
 	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { EllipsisVerticalIcon } from '@heroicons/react/16/solid';
-import type { TeamMemberSchema } from '@interval.so/api/app/team_member/schemas/team_member_schema';
-import type { Table } from '@tanstack/react-table';
-import { useState } from 'react';
 import { BatchArchiveItem } from './batch-archive-item';
 import { BatchDeleteDialogContent, BatchDeleteItem } from './batch-delete-item';
 import { BatchUpdateAttendanceItem } from './batch-update-attendance-item';

--- a/apps/web/src/components/manager/members/members-table/batch-actions/batch-archive-item.tsx
+++ b/apps/web/src/components/manager/members/members-table/batch-actions/batch-archive-item.tsx
@@ -1,10 +1,10 @@
-import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
-import { trpc } from '@/src/trpc/trpc-client';
 import { ArchiveBoxIcon, ArrowUpIcon } from '@heroicons/react/16/solid';
 import type { TeamMemberSchema } from '@interval.so/api/app/team_member/schemas/team_member_schema';
 import type { Table } from '@tanstack/react-table';
 import { useState } from 'react';
 import { toast } from 'sonner';
+import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
+import { trpc } from '@/src/trpc/trpc-client';
 
 type Props = {
 	table: Table<TeamMemberSchema>;

--- a/apps/web/src/components/manager/members/members-table/batch-actions/batch-delete-item.tsx
+++ b/apps/web/src/components/manager/members/members-table/batch-actions/batch-delete-item.tsx
@@ -1,3 +1,8 @@
+import { TrashIcon } from '@heroicons/react/16/solid';
+import type { TeamMemberSchema } from '@interval.so/api/app/team_member/schemas/team_member_schema';
+import type { Table } from '@tanstack/react-table';
+import { useState } from 'react';
+import { toast } from 'sonner';
 import {
 	AlertDialogAction,
 	AlertDialogCancel,
@@ -11,11 +16,6 @@ import {
 import { buttonVariants } from '@/components/ui/button';
 import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
 import { trpc } from '@/src/trpc/trpc-client';
-import { TrashIcon } from '@heroicons/react/16/solid';
-import type { TeamMemberSchema } from '@interval.so/api/app/team_member/schemas/team_member_schema';
-import type { Table } from '@tanstack/react-table';
-import { useState } from 'react';
-import { toast } from 'sonner';
 
 export function BatchDeleteItem() {
 	return (

--- a/apps/web/src/components/manager/members/members-table/batch-actions/batch-update-attendance-item.tsx
+++ b/apps/web/src/components/manager/members/members-table/batch-actions/batch-update-attendance-item.tsx
@@ -1,10 +1,10 @@
-import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
-import { trpc } from '@/src/trpc/trpc-client';
 import { ArrowLeftEndOnRectangleIcon, ArrowRightStartOnRectangleIcon } from '@heroicons/react/16/solid';
 import type { TeamMemberSchema } from '@interval.so/api/app/team_member/schemas/team_member_schema';
 import type { Table } from '@tanstack/react-table';
 import { useState } from 'react';
 import { toast } from 'sonner';
+import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
+import { trpc } from '@/src/trpc/trpc-client';
 
 type Props = {
 	table: Table<TeamMemberSchema>;

--- a/apps/web/src/components/manager/members/members-table/columns.tsx
+++ b/apps/web/src/components/manager/members/members-table/columns.tsx
@@ -1,5 +1,11 @@
 'use client';
 
+import { ArchiveBoxIcon, UserIcon } from '@heroicons/react/16/solid';
+import type { TeamMemberSchema } from '@interval.so/api/app/team_member/schemas/team_member_schema';
+import { Sort } from '@jonahsnider/util';
+import type { ColumnDef } from '@tanstack/react-table';
+import { Link } from 'next-view-transitions';
+import { useContext } from 'react';
 import { buttonVariants } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -7,12 +13,6 @@ import { cn } from '@/lib/utils';
 import { SortableHeader } from '@/src/components/data-tables/sortable-header';
 import { TeamSlugContext } from '@/src/components/team-dashboard/team-slug-provider';
 import { formatDate } from '@/src/utils/date-format';
-import { ArchiveBoxIcon, UserIcon } from '@heroicons/react/16/solid';
-import type { TeamMemberSchema } from '@interval.so/api/app/team_member/schemas/team_member_schema';
-import { Sort } from '@jonahsnider/util';
-import type { ColumnDef } from '@tanstack/react-table';
-import { Link } from 'next-view-transitions';
-import { useContext } from 'react';
 import { toTimeRange } from '../../period-select/duration-slug';
 import { BatchActionsDropdown } from './batch-actions/batch-actions-dropdown';
 import type { LastSeenAtFilter } from './members-table-buttons';

--- a/apps/web/src/components/manager/members/members-table/members-table-buttons.tsx
+++ b/apps/web/src/components/manager/members/members-table/members-table-buttons.tsx
@@ -1,11 +1,11 @@
 'use client';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { DataTableFacetedFilter } from '@/src/components/data-tables/faceted-filter';
 import { ArchiveBoxIcon, CheckIcon, UserIcon, XMarkIcon } from '@heroicons/react/16/solid';
 import type { TeamMemberSchema } from '@interval.so/api/app/team_member/schemas/team_member_schema';
 import type { Table } from '@tanstack/react-table';
 import type { SelectRangeEventHandler } from 'react-day-picker';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { DataTableFacetedFilter } from '@/src/components/data-tables/faceted-filter';
 import { DurationSlug } from '../../period-select/duration-slug';
 import { PeriodSelect } from '../../period-select/period-select';
 

--- a/apps/web/src/components/manager/members/members-table/members-table.client.tsx
+++ b/apps/web/src/components/manager/members/members-table/members-table.client.tsx
@@ -1,26 +1,26 @@
 'use client';
 
-import { Skeleton } from '@/components/ui/skeleton';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
-import { TablePagination } from '@/src/components/data-tables/table-pagination';
-import { TableSelectionStatus } from '@/src/components/data-tables/table-selection-status';
-import { trpc } from '@/src/trpc/trpc-client';
 import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import type { TeamMemberSchema } from '@interval.so/api/app/team_member/schemas/team_member_schema';
 import {
 	type ColumnFiltersState,
-	type PaginationState,
-	type SortingState,
 	flexRender,
 	getCoreRowModel,
 	getFilteredRowModel,
 	getPaginationRowModel,
 	getSortedRowModel,
+	type PaginationState,
+	type SortingState,
 	useReactTable,
 } from '@tanstack/react-table';
 import clsx from 'clsx';
 import Fuse from 'fuse.js';
 import { useEffect, useState } from 'react';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { TablePagination } from '@/src/components/data-tables/table-pagination';
+import { TableSelectionStatus } from '@/src/components/data-tables/table-selection-status';
+import { trpc } from '@/src/trpc/trpc-client';
 import { columns } from './columns';
 import { MembersTableButtons } from './members-table-buttons';
 import { InnerTableContainer, OuterTableContainer } from './members-table-common';

--- a/apps/web/src/components/manager/members/members-table/members-table.tsx
+++ b/apps/web/src/components/manager/members/members-table/members-table.tsx
@@ -1,8 +1,8 @@
 import 'server-only';
 
-import { trpcServer } from '@/src/trpc/trpc-server';
 import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import { Suspense } from 'react';
+import { trpcServer } from '@/src/trpc/trpc-server';
 import { MembersTableClient } from './members-table.client';
 
 type Props = {

--- a/apps/web/src/components/manager/members/members-table/row-actions/archive-member-item.tsx
+++ b/apps/web/src/components/manager/members/members-table/row-actions/archive-member-item.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
-import { trpc } from '@/src/trpc/trpc-client';
 import { ArchiveBoxArrowDownIcon } from '@heroicons/react/16/solid';
 import type { TeamMemberSchema } from '@interval.so/api/app/team_member/schemas/team_member_schema';
 import { useState } from 'react';
 import { toast } from 'sonner';
+import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
+import { trpc } from '@/src/trpc/trpc-client';
 
 type Props = {
 	member: Pick<TeamMemberSchema, 'id' | 'name' | 'archived'>;

--- a/apps/web/src/components/manager/members/members-table/row-actions/delete-member-item.tsx
+++ b/apps/web/src/components/manager/members/members-table/row-actions/delete-member-item.tsx
@@ -1,5 +1,9 @@
 'use client';
 
+import { TrashIcon } from '@heroicons/react/16/solid';
+import type { TeamMemberSchema } from '@interval.so/api/app/team_member/schemas/team_member_schema';
+import { useState } from 'react';
+import { toast } from 'sonner';
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -14,10 +18,6 @@ import {
 import { buttonVariants } from '@/components/ui/button';
 import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
 import { trpc } from '@/src/trpc/trpc-client';
-import { TrashIcon } from '@heroicons/react/16/solid';
-import type { TeamMemberSchema } from '@interval.so/api/app/team_member/schemas/team_member_schema';
-import { useState } from 'react';
-import { toast } from 'sonner';
 
 type Props = {
 	member: Pick<TeamMemberSchema, 'id' | 'name'>;

--- a/apps/web/src/components/manager/members/members-table/row-actions/row-actions-dropdown.tsx
+++ b/apps/web/src/components/manager/members/members-table/row-actions/row-actions-dropdown.tsx
@@ -1,5 +1,10 @@
 'use client';
 
+import { EllipsisVerticalIcon } from '@heroicons/react/16/solid';
+import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
+import type { TeamMemberSchema } from '@interval.so/api/app/team_member/schemas/team_member_schema';
+import clsx from 'clsx';
+import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import {
 	DropdownMenu,
@@ -7,11 +12,6 @@ import {
 	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { EllipsisVerticalIcon } from '@heroicons/react/16/solid';
-import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
-import type { TeamMemberSchema } from '@interval.so/api/app/team_member/schemas/team_member_schema';
-import clsx from 'clsx';
-import { useState } from 'react';
 import { ArchiveMemberItem } from './archive-member-item';
 import { DeleteMemberItem } from './delete-member-item';
 import { UpdateAttendanceItem } from './update-attendance-item';

--- a/apps/web/src/components/manager/members/members-table/row-actions/update-attendance-item.tsx
+++ b/apps/web/src/components/manager/members/members-table/row-actions/update-attendance-item.tsx
@@ -1,9 +1,9 @@
-import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
-import { trpc } from '@/src/trpc/trpc-client';
 import { ArrowLeftEndOnRectangleIcon, ArrowRightStartOnRectangleIcon } from '@heroicons/react/16/solid';
 import type { TeamMemberSchema } from '@interval.so/api/app/team_member/schemas/team_member_schema';
 import { useState } from 'react';
 import { toast } from 'sonner';
+import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
+import { trpc } from '@/src/trpc/trpc-client';
 
 type Props = {
 	member: Pick<TeamMemberSchema, 'id' | 'name' | 'signedInAt'>;

--- a/apps/web/src/components/manager/members/members-table/row-actions/view-member-item.tsx
+++ b/apps/web/src/components/manager/members/members-table/row-actions/view-member-item.tsx
@@ -1,8 +1,8 @@
-import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
 import { MagnifyingGlassIcon } from '@heroicons/react/16/solid';
 import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import type { TeamMemberSchema } from '@interval.so/api/app/team_member/schemas/team_member_schema';
 import { Link } from 'next-view-transitions';
+import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
 
 type Props = {
 	team: Pick<TeamSchema, 'slug'>;

--- a/apps/web/src/components/manager/members/view-member/edit-member-name-dialog.tsx
+++ b/apps/web/src/components/manager/members/view-member/edit-member-name-dialog.tsx
@@ -1,5 +1,11 @@
 'use client';
 
+import { zodResolver } from '@hookform/resolvers/zod';
+import { TeamMemberSchema } from '@interval.so/api/app/team_member/schemas/team_member_schema';
+import { type PropsWithChildren, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { toast } from 'sonner';
+import type { z } from 'zod';
 import { Button } from '@/components/ui/button';
 import {
 	Dialog,
@@ -13,12 +19,6 @@ import {
 import { Form, FormControl, FormField, FormItem, FormMessage } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { trpc } from '@/src/trpc/trpc-client';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { TeamMemberSchema } from '@interval.so/api/app/team_member/schemas/team_member_schema';
-import { type PropsWithChildren, useState } from 'react';
-import { useForm } from 'react-hook-form';
-import { toast } from 'sonner';
-import type { z } from 'zod';
 
 type Props = PropsWithChildren<{
 	member: Pick<TeamMemberSchema, 'id' | 'name'>;

--- a/apps/web/src/components/manager/members/view-member/member-actions-dropdown/member-actions-dropdown.client.tsx
+++ b/apps/web/src/components/manager/members/view-member/member-actions-dropdown/member-actions-dropdown.client.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { trpc } from '@/src/trpc/trpc-client';
 import type { TeamMemberSchema } from '@interval.so/api/app/team_member/schemas/team_member_schema';
 import { use, useState } from 'react';
+import { trpc } from '@/src/trpc/trpc-client';
 import { MemberRowActionsDropdown } from '../../members-table/row-actions/row-actions-dropdown';
 
 type Props = {

--- a/apps/web/src/components/manager/members/view-member/member-actions-dropdown/member-actions-dropdown.server.tsx
+++ b/apps/web/src/components/manager/members/view-member/member-actions-dropdown/member-actions-dropdown.server.tsx
@@ -1,7 +1,7 @@
-import { Skeleton } from '@/components/ui/skeleton';
-import { trpcServer } from '@/src/trpc/trpc-server';
 import type { TeamMemberSchema } from '@interval.so/api/app/team_member/schemas/team_member_schema';
 import { Suspense } from 'react';
+import { Skeleton } from '@/components/ui/skeleton';
+import { trpcServer } from '@/src/trpc/trpc-server';
 import { MemberActionsDropdownClient } from './member-actions-dropdown.client';
 
 export function MemberActionsDropdown({ member }: { member: Pick<TeamMemberSchema, 'id'> }) {

--- a/apps/web/src/components/manager/members/view-member/member-attendance-section/add-attendance-button.tsx
+++ b/apps/web/src/components/manager/members/view-member/member-attendance-section/add-attendance-button.tsx
@@ -1,10 +1,5 @@
 'use client';
 
-import { Button } from '@/components/ui/button';
-import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
-import { DateTimeRangePicker } from '@/src/components/date-time-range-picker';
-import { trpc } from '@/src/trpc/trpc-client';
 import { PlusIcon } from '@heroicons/react/16/solid';
 import { zodResolver } from '@hookform/resolvers/zod';
 import type { TeamMemberSchema } from '@interval.so/api/app/team_member/schemas/team_member_schema';
@@ -13,6 +8,11 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import { z } from 'zod';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
+import { DateTimeRangePicker } from '@/src/components/date-time-range-picker';
+import { trpc } from '@/src/trpc/trpc-client';
 
 type Props = {
 	member: Pick<TeamMemberSchema, 'id'>;

--- a/apps/web/src/components/manager/members/view-member/member-attendance-section/meeting-date-range-picker.tsx
+++ b/apps/web/src/components/manager/members/view-member/member-attendance-section/meeting-date-range-picker.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { DateTimeRangePicker } from '@/src/components/date-time-range-picker';
-import { trpc } from '@/src/trpc/trpc-client';
 import type { AttendanceEntrySchema } from '@interval.so/api/app/team_member_attendance/schemas/attendance_entry_schema';
 import type { TimeRangeSchema } from '@interval.so/api/app/team_stats/schemas/time_range_schema';
 import { type ComponentProps, useState } from 'react';
 import { toast } from 'sonner';
+import { DateTimeRangePicker } from '@/src/components/date-time-range-picker';
+import { trpc } from '@/src/trpc/trpc-client';
 
 type Props = {
 	meeting: Pick<AttendanceEntrySchema, 'attendanceId' | 'startedAt' | 'endedAt'>;

--- a/apps/web/src/components/manager/members/view-member/member-attendance-section/member-attendance-table/batch-actions/batch-actions-dropdown.tsx
+++ b/apps/web/src/components/manager/members/view-member/member-attendance-section/member-attendance-table/batch-actions/batch-actions-dropdown.tsx
@@ -1,5 +1,8 @@
 'use client';
 
+import { EllipsisVerticalIcon } from '@heroicons/react/16/solid';
+import type { Table } from '@tanstack/react-table';
+import { useState } from 'react';
 import { AlertDialog } from '@/components/ui/alert-dialog';
 import { Button } from '@/components/ui/button';
 import {
@@ -8,9 +11,6 @@ import {
 	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { EllipsisVerticalIcon } from '@heroicons/react/16/solid';
-import type { Table } from '@tanstack/react-table';
-import { useState } from 'react';
 import type { MembersTableMeetingRow } from '../columns';
 import { BatchDeleteDialogContent, BatchDeleteItem } from './batch-delete-item';
 import { MergeAttendanceEntriesItem } from './merge-attendance-entries-item';

--- a/apps/web/src/components/manager/members/view-member/member-attendance-section/member-attendance-table/batch-actions/batch-delete-item.tsx
+++ b/apps/web/src/components/manager/members/view-member/member-attendance-section/member-attendance-table/batch-actions/batch-delete-item.tsx
@@ -1,3 +1,7 @@
+import { TrashIcon } from '@heroicons/react/16/solid';
+import type { Table } from '@tanstack/react-table';
+import { useState } from 'react';
+import { toast } from 'sonner';
 import {
 	AlertDialogCancel,
 	AlertDialogContent,
@@ -9,17 +13,9 @@ import {
 import { Button } from '@/components/ui/button';
 import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
 import { trpc } from '@/src/trpc/trpc-client';
-import { TrashIcon } from '@heroicons/react/16/solid';
-import type { Table } from '@tanstack/react-table';
-import { useState } from 'react';
-import { toast } from 'sonner';
 import type { MembersTableMeetingRow } from '../columns';
 
-export function BatchDeleteItem({
-	setDialogOpen,
-}: {
-	setDialogOpen: (open: boolean) => void;
-}) {
+export function BatchDeleteItem({ setDialogOpen }: { setDialogOpen: (open: boolean) => void }) {
 	return (
 		<DropdownMenuItem
 			className='text-destructive focus:text-destructive focus:bg-destructive/10'

--- a/apps/web/src/components/manager/members/view-member/member-attendance-section/member-attendance-table/batch-actions/merge-attendance-entries-item.tsx
+++ b/apps/web/src/components/manager/members/view-member/member-attendance-section/member-attendance-table/batch-actions/merge-attendance-entries-item.tsx
@@ -1,9 +1,9 @@
-import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
-import { trpc } from '@/src/trpc/trpc-client';
 import { Square3Stack3DIcon } from '@heroicons/react/16/solid';
 import type { Table } from '@tanstack/react-table';
 import { useState } from 'react';
 import { toast } from 'sonner';
+import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
+import { trpc } from '@/src/trpc/trpc-client';
 import type { MembersTableMeetingRow } from '../columns';
 
 type Props = {

--- a/apps/web/src/components/manager/members/view-member/member-attendance-section/member-attendance-table/columns.tsx
+++ b/apps/web/src/components/manager/members/view-member/member-attendance-section/member-attendance-table/columns.tsx
@@ -1,11 +1,11 @@
 'use client';
-import { Checkbox } from '@/components/ui/checkbox';
-import { SortableHeader } from '@/src/components/data-tables/sortable-header';
-import { formatDuration } from '@/src/utils/date-format';
 import type { AttendanceEntrySchema } from '@interval.so/api/app/team_member_attendance/schemas/attendance_entry_schema';
 import { Sort } from '@jonahsnider/util';
 import type { ColumnDef } from '@tanstack/react-table';
 import { type Duration, intervalToDuration, milliseconds } from 'date-fns';
+import { Checkbox } from '@/components/ui/checkbox';
+import { SortableHeader } from '@/src/components/data-tables/sortable-header';
+import { formatDuration } from '@/src/utils/date-format';
 import { MeetingDateRangePicker } from '../meeting-date-range-picker';
 import { BatchActionsDropdown } from './batch-actions/batch-actions-dropdown';
 import { RowActionsDropdown } from './row-actions-dropdown';

--- a/apps/web/src/components/manager/members/view-member/member-attendance-section/member-attendance-table/member-attendance-table.client.tsx
+++ b/apps/web/src/components/manager/members/view-member/member-attendance-section/member-attendance-table/member-attendance-table.client.tsx
@@ -1,23 +1,23 @@
 'use client';
 
+import type { TeamMemberSchema } from '@interval.so/api/app/team_member/schemas/team_member_schema';
+import type { AttendanceEntrySchema } from '@interval.so/api/app/team_member_attendance/schemas/attendance_entry_schema';
+import {
+	flexRender,
+	getCoreRowModel,
+	getPaginationRowModel,
+	getSortedRowModel,
+	type SortingState,
+	useReactTable,
+} from '@tanstack/react-table';
+import { useQueryStates } from 'nuqs';
+import { useMemo, useState } from 'react';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { TablePagination } from '@/src/components/data-tables/table-pagination';
 import { TableSelectionStatus } from '@/src/components/data-tables/table-selection-status';
 import { toTimeFilter } from '@/src/components/manager/period-select/duration-slug';
 import { trpc } from '@/src/trpc/trpc-client';
-import type { TeamMemberSchema } from '@interval.so/api/app/team_member/schemas/team_member_schema';
-import type { AttendanceEntrySchema } from '@interval.so/api/app/team_member_attendance/schemas/attendance_entry_schema';
-import {
-	type SortingState,
-	flexRender,
-	getCoreRowModel,
-	getPaginationRowModel,
-	getSortedRowModel,
-	useReactTable,
-} from '@tanstack/react-table';
-import { useQueryStates } from 'nuqs';
-import { useMemo, useState } from 'react';
 import { searchParamParsers } from '../../search-params';
 import { columns } from './columns';
 

--- a/apps/web/src/components/manager/members/view-member/member-attendance-section/member-attendance-table/member-attendance-table.tsx
+++ b/apps/web/src/components/manager/members/view-member/member-attendance-section/member-attendance-table/member-attendance-table.tsx
@@ -1,7 +1,7 @@
-import { trpcServer } from '@/src/trpc/trpc-server';
 import type { TeamMemberSchema } from '@interval.so/api/app/team_member/schemas/team_member_schema';
 import type { TimeFilterSchema } from '@interval.so/api/app/team_stats/schemas/time_filter_schema';
 import { Suspense } from 'react';
+import { trpcServer } from '@/src/trpc/trpc-server';
 import 'server-only';
 import { MemberAttendanceTableClient } from './member-attendance-table.client';
 

--- a/apps/web/src/components/manager/members/view-member/member-attendance-section/member-attendance-table/row-actions-dropdown.tsx
+++ b/apps/web/src/components/manager/members/view-member/member-attendance-section/member-attendance-table/row-actions-dropdown.tsx
@@ -1,5 +1,8 @@
 'use client';
 
+import { EllipsisVerticalIcon, TrashIcon } from '@heroicons/react/16/solid';
+import { useState } from 'react';
+import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import {
 	DropdownMenu,
@@ -8,9 +11,6 @@ import {
 	DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { trpc } from '@/src/trpc/trpc-client';
-import { EllipsisVerticalIcon, TrashIcon } from '@heroicons/react/16/solid';
-import { useState } from 'react';
-import { toast } from 'sonner';
 import type { MembersTableMeetingRow } from './columns';
 
 type Props = {

--- a/apps/web/src/components/manager/members/view-member/view-member-page-header/title.client.tsx
+++ b/apps/web/src/components/manager/members/view-member/view-member-page-header/title.client.tsx
@@ -1,8 +1,8 @@
 'use client';
-import { PageHeaderTitle } from '@/src/components/page-header';
-import { trpc } from '@/src/trpc/trpc-client';
 import type { TeamMemberSchema } from '@interval.so/api/app/team_member/schemas/team_member_schema';
 import { useState } from 'react';
+import { PageHeaderTitle } from '@/src/components/page-header';
+import { trpc } from '@/src/trpc/trpc-client';
 
 type Props = {
 	member: Pick<TeamMemberSchema, 'id'>;

--- a/apps/web/src/components/manager/members/view-member/view-member-page-header/title.server.tsx
+++ b/apps/web/src/components/manager/members/view-member/view-member-page-header/title.server.tsx
@@ -1,7 +1,7 @@
-import { EditMemberNameDialog } from '@/src/components/manager/members/view-member/edit-member-name-dialog';
-import { trpcServer } from '@/src/trpc/trpc-server';
 import { PencilSquareIcon } from '@heroicons/react/16/solid';
 import type { TeamMemberSchema } from '@interval.so/api/app/team_member/schemas/team_member_schema';
+import { EditMemberNameDialog } from '@/src/components/manager/members/view-member/edit-member-name-dialog';
+import { trpcServer } from '@/src/trpc/trpc-server';
 import { TitleClient } from './title.client';
 
 type Props = {

--- a/apps/web/src/components/manager/members/view-member/view-member-page-header/view-member-page-header.tsx
+++ b/apps/web/src/components/manager/members/view-member/view-member-page-header/view-member-page-header.tsx
@@ -1,10 +1,10 @@
-import { buttonVariants } from '@/components/ui/button';
-import { cn } from '@/lib/utils';
-import { PageHeader } from '@/src/components/page-header';
 import { ArrowLeftIcon } from '@heroicons/react/16/solid';
 import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import type { TeamMemberSchema } from '@interval.so/api/app/team_member/schemas/team_member_schema';
 import { Link } from 'next-view-transitions';
+import { buttonVariants } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { PageHeader } from '@/src/components/page-header';
 import { MemberActionsDropdown } from '../member-actions-dropdown/member-actions-dropdown.server';
 import { Title } from './title.server';
 

--- a/apps/web/src/components/manager/navbar/manager-navbar-inner.tsx
+++ b/apps/web/src/components/manager/navbar/manager-navbar-inner.tsx
@@ -1,11 +1,10 @@
 'use client';
 
-import { AnimatePresence, type Variants, motion } from 'framer-motion';
-
 import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import clsx from 'clsx';
-import { Link } from 'next-view-transitions';
+import { AnimatePresence, motion, type Variants } from 'framer-motion';
 import { usePathname } from 'next/navigation';
+import { Link } from 'next-view-transitions';
 
 type NavbarEntryData = {
 	label: string;

--- a/apps/web/src/components/manager/period-select/duration-slug.ts
+++ b/apps/web/src/components/manager/period-select/duration-slug.ts
@@ -45,11 +45,7 @@ export function toTimeFilter(searchParams: {
 	};
 }
 
-export function toTimeRange(searchParams: {
-	duration: DurationSlug;
-	start?: Date | null;
-	end?: Date | null;
-}): {
+export function toTimeRange(searchParams: { duration: DurationSlug; start?: Date | null; end?: Date | null }): {
 	current: TimeRangeSchema;
 	previous?: TimeRangeSchema;
 } {

--- a/apps/web/src/components/manager/period-select/period-select.tsx
+++ b/apps/web/src/components/manager/period-select/period-select.tsx
@@ -1,5 +1,9 @@
 'use client';
 
+import { CalendarIcon } from '@heroicons/react/16/solid';
+import clsx from 'clsx';
+import { type ComponentProps, type ReactNode, useState } from 'react';
+import type { SelectRangeEventHandler } from 'react-day-picker';
 import { Button } from '@/components/ui/button';
 import { Calendar } from '@/components/ui/calendar';
 import {
@@ -14,10 +18,6 @@ import {
 	DropdownMenuSubTrigger,
 	DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { CalendarIcon } from '@heroicons/react/16/solid';
-import clsx from 'clsx';
-import { type ComponentProps, type ReactNode, useState } from 'react';
-import type { SelectRangeEventHandler } from 'react-day-picker';
 import { DurationSlug, durationLabel } from './duration-slug';
 
 type Props = {

--- a/apps/web/src/components/manager/settings/general/delete-team-card/delete-team-card.client.tsx
+++ b/apps/web/src/components/manager/settings/general/delete-team-card/delete-team-card.client.tsx
@@ -1,5 +1,9 @@
 'use client';
 
+import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { toast } from 'sonner';
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -14,10 +18,6 @@ import {
 import { Button, buttonVariants } from '@/components/ui/button';
 import { Card, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { trpc } from '@/src/trpc/trpc-client';
-import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
-import { useRouter } from 'next/navigation';
-import { useState } from 'react';
-import { toast } from 'sonner';
 
 type Props = {
 	team: Pick<TeamSchema, 'slug'>;

--- a/apps/web/src/components/manager/settings/general/delete-team-card/delete-team-card.server.tsx
+++ b/apps/web/src/components/manager/settings/general/delete-team-card/delete-team-card.server.tsx
@@ -1,7 +1,7 @@
-import { SettingsCardSkeleton } from '@/src/components/settings-card-skeleton';
-import { trpcServer } from '@/src/trpc/trpc-server';
 import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import { Suspense } from 'react';
+import { SettingsCardSkeleton } from '@/src/components/settings-card-skeleton';
+import { trpcServer } from '@/src/trpc/trpc-server';
 import { DeleteTeamCardClient } from './delete-team-card.client';
 
 type Props = {

--- a/apps/web/src/components/manager/settings/general/leave-team-card/leave-team-card.client.tsx
+++ b/apps/web/src/components/manager/settings/general/leave-team-card/leave-team-card.client.tsx
@@ -1,5 +1,9 @@
 'use client';
 
+import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { toast } from 'sonner';
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -13,10 +17,6 @@ import {
 } from '@/components/ui/alert-dialog';
 import { Button, buttonVariants } from '@/components/ui/button';
 import { trpc } from '@/src/trpc/trpc-client';
-import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
-import { useRouter } from 'next/navigation';
-import { useState } from 'react';
-import { toast } from 'sonner';
 
 type Props = {
 	team: Pick<TeamSchema, 'slug'>;

--- a/apps/web/src/components/manager/settings/general/leave-team-card/leave-team-card.server.tsx
+++ b/apps/web/src/components/manager/settings/general/leave-team-card/leave-team-card.server.tsx
@@ -1,8 +1,8 @@
+import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
+import { Suspense } from 'react';
 import { Card, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { SettingsCardButtonSkeleton } from '@/src/components/settings-card-skeleton';
 import { trpcServer } from '@/src/trpc/trpc-server';
-import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
-import { Suspense } from 'react';
 import { LeaveTeamCardActionAllowed } from './leave-team-card.client';
 
 type Props = {

--- a/apps/web/src/components/manager/settings/general/team-display-name-card/team-display-name-card.client.tsx
+++ b/apps/web/src/components/manager/settings/general/team-display-name-card/team-display-name-card.client.tsx
@@ -1,10 +1,5 @@
 'use client';
 
-import { Button } from '@/components/ui/button';
-import { CardContent, CardFooter } from '@/components/ui/card';
-import { Form, FormControl, FormField, FormItem, FormMessage } from '@/components/ui/form';
-import { Input } from '@/components/ui/input';
-import { trpc } from '@/src/trpc/trpc-client';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import { useRouter } from 'next/navigation';
@@ -12,6 +7,11 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import type { z } from 'zod';
+import { Button } from '@/components/ui/button';
+import { CardContent, CardFooter } from '@/components/ui/card';
+import { Form, FormControl, FormField, FormItem, FormMessage } from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { trpc } from '@/src/trpc/trpc-client';
 
 const formSchema = TeamSchema.pick({ displayName: true });
 

--- a/apps/web/src/components/manager/settings/general/team-display-name-card/team-display-name-card.server.tsx
+++ b/apps/web/src/components/manager/settings/general/team-display-name-card/team-display-name-card.server.tsx
@@ -1,9 +1,9 @@
+import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
+import { Suspense } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { ReadonlyTextField } from '@/src/components/readonly-text-field';
 import { SettingsCardContentSkeleton, SettingsCardFooterSkeleton } from '@/src/components/settings-card-skeleton';
 import { trpcServer } from '@/src/trpc/trpc-server';
-import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
-import { Suspense } from 'react';
 import { TeamDisplayNameEditForm } from './team-display-name-card.client';
 
 type Props = {

--- a/apps/web/src/components/manager/settings/general/team-password-card/team-password-card.client.tsx
+++ b/apps/web/src/components/manager/settings/general/team-password-card/team-password-card.client.tsx
@@ -1,16 +1,16 @@
 'use client';
 
-import { Button } from '@/components/ui/button';
-import { CardContent, CardFooter } from '@/components/ui/card';
-import { Form, FormField, FormItem, FormMessage } from '@/components/ui/form';
-import { CopyButtonInput } from '@/src/components/copy-button-input';
-import { trpc } from '@/src/trpc/trpc-client';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import type { z } from 'zod';
+import { Button } from '@/components/ui/button';
+import { CardContent, CardFooter } from '@/components/ui/card';
+import { Form, FormField, FormItem, FormMessage } from '@/components/ui/form';
+import { CopyButtonInput } from '@/src/components/copy-button-input';
+import { trpc } from '@/src/trpc/trpc-client';
 
 type Props = {
 	team: Pick<TeamSchema, 'slug'>;

--- a/apps/web/src/components/manager/settings/general/team-password-card/team-password-card.server.tsx
+++ b/apps/web/src/components/manager/settings/general/team-password-card/team-password-card.server.tsx
@@ -1,9 +1,9 @@
+import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
+import { Suspense } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { CopyButtonInput } from '@/src/components/copy-button-input';
 import { SettingsCardContentSkeleton, SettingsCardFooterSkeleton } from '@/src/components/settings-card-skeleton';
 import { trpcServer } from '@/src/trpc/trpc-server';
-import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
-import { Suspense } from 'react';
 import { TeamPasswordEditForm } from './team-password-card.client';
 
 type Props = {

--- a/apps/web/src/components/manager/settings/general/team-url-card/team-url-card.client.tsx
+++ b/apps/web/src/components/manager/settings/general/team-url-card/team-url-card.client.tsx
@@ -1,11 +1,5 @@
 'use client';
 
-import { Button } from '@/components/ui/button';
-import { CardContent, CardFooter } from '@/components/ui/card';
-import { Form, FormField, FormItem, FormMessage } from '@/components/ui/form';
-import { CopyButtonInput } from '@/src/components/copy-button-input';
-import { ReadonlyTextField } from '@/src/components/readonly-text-field';
-import { trpc } from '@/src/trpc/trpc-client';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import { useRouter } from 'next/navigation';
@@ -13,6 +7,12 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import type { z } from 'zod';
+import { Button } from '@/components/ui/button';
+import { CardContent, CardFooter } from '@/components/ui/card';
+import { Form, FormField, FormItem, FormMessage } from '@/components/ui/form';
+import { CopyButtonInput } from '@/src/components/copy-button-input';
+import { ReadonlyTextField } from '@/src/components/readonly-text-field';
+import { trpc } from '@/src/trpc/trpc-client';
 
 type Props = {
 	team: Pick<TeamSchema, 'slug'>;

--- a/apps/web/src/components/manager/settings/general/team-url-card/team-url-card.server.tsx
+++ b/apps/web/src/components/manager/settings/general/team-url-card/team-url-card.server.tsx
@@ -1,9 +1,9 @@
+import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
+import { Suspense } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { CopyButtonInput } from '@/src/components/copy-button-input';
 import { SettingsCardContentSkeleton, SettingsCardFooterSkeleton } from '@/src/components/settings-card-skeleton';
 import { trpcServer } from '@/src/trpc/trpc-server';
-import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
-import { Suspense } from 'react';
 import { TeamUrlCardEditForm } from './team-url-card.client';
 
 type Props = {

--- a/apps/web/src/components/manager/settings/managers/manager-invite-link-card/manager-invite-link-card.client.tsx
+++ b/apps/web/src/components/manager/settings/managers/manager-invite-link-card/manager-invite-link-card.client.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { Button } from '@/components/ui/button';
-import { trpc } from '@/src/trpc/trpc-client';
 import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { trpc } from '@/src/trpc/trpc-client';
 import { inviteLinkUrl } from './shared';
 
 type Props = {

--- a/apps/web/src/components/manager/settings/managers/manager-invite-link-card/manager-invite-link-card.server.tsx
+++ b/apps/web/src/components/manager/settings/managers/manager-invite-link-card/manager-invite-link-card.server.tsx
@@ -1,9 +1,9 @@
+import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
+import { Suspense } from 'react';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { CopyButtonInput } from '@/src/components/copy-button-input';
 import { SettingsCardContentSkeleton, SettingsCardSkeleton } from '@/src/components/settings-card-skeleton';
 import { trpcServer } from '@/src/trpc/trpc-server';
-import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
-import { Suspense } from 'react';
 import { ManageInviteLinkCardButton } from './manager-invite-link-card.client';
 import { inviteLinkUrl } from './shared';
 

--- a/apps/web/src/components/manager/settings/managers/managers-table-card/managers-table-card.client.tsx
+++ b/apps/web/src/components/manager/settings/managers/managers-table-card/managers-table-card.client.tsx
@@ -1,14 +1,5 @@
 'use client';
 
-import { Button } from '@/components/ui/button';
-import {
-	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuItem,
-	DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
-import { Select, SelectContent, SelectGroup, SelectItem, SelectSeparator, SelectTrigger } from '@/components/ui/select';
-import { trpc } from '@/src/trpc/trpc-client';
 import { EllipsisHorizontalIcon } from '@heroicons/react/16/solid';
 import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import { TeamManagerSchema } from '@interval.so/api/app/team_manager/schemas/team_manager_schema';
@@ -18,6 +9,15 @@ import clsx from 'clsx';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Select, SelectContent, SelectGroup, SelectItem, SelectSeparator, SelectTrigger } from '@/components/ui/select';
+import { trpc } from '@/src/trpc/trpc-client';
 
 export function ManagersTableRoleSelect({
 	manager,

--- a/apps/web/src/components/manager/settings/managers/managers-table-card/managers-table-card.server.tsx
+++ b/apps/web/src/components/manager/settings/managers/managers-table-card/managers-table-card.server.tsx
@@ -1,14 +1,14 @@
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import {
-	type TeamManagerSchema,
 	getAllowedRoleModifications,
+	type TeamManagerSchema,
 } from '@interval.so/api/app/team_manager/schemas/team_manager_schema';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import 'server-only';
+import { Suspense } from 'react';
 import { Skeleton } from '@/components/ui/skeleton';
 import { trpcServer } from '@/src/trpc/trpc-server';
-import { Suspense } from 'react';
 import { ManagersTableRoleSelect, ManagersTableRowActions } from './managers-table-card.client';
 
 type Props = {

--- a/apps/web/src/components/members/create-member/create-member-dialog.tsx
+++ b/apps/web/src/components/members/create-member/create-member-dialog.tsx
@@ -1,10 +1,5 @@
 'use client';
 
-import { Button, type ButtonProps } from '@/components/ui/button';
-import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
-import { Input } from '@/components/ui/input';
-import { trpc } from '@/src/trpc/trpc-client';
 import { zodResolver } from '@hookform/resolvers/zod';
 import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import { TeamMemberSchema } from '@interval.so/api/app/team_member/schemas/team_member_schema';
@@ -12,6 +7,11 @@ import { type PropsWithChildren, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import type { z } from 'zod';
+import { Button, type ButtonProps } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { trpc } from '@/src/trpc/trpc-client';
 
 const formSchema = TeamMemberSchema.pick({ name: true });
 

--- a/apps/web/src/components/navbar/base-navbar.tsx
+++ b/apps/web/src/components/navbar/base-navbar.tsx
@@ -1,6 +1,6 @@
-import { cn } from '@/lib/utils';
 import { Link } from 'next-view-transitions';
 import type { ReactNode } from 'react';
+import { cn } from '@/lib/utils';
 
 type Props = {
 	className?: string;

--- a/apps/web/src/components/navbar/navbar.tsx
+++ b/apps/web/src/components/navbar/navbar.tsx
@@ -1,8 +1,8 @@
-import { trpcServer } from '@/src/trpc/trpc-server';
 import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import { unstable_noStore as noStore } from 'next/cache';
 import { type PropsWithChildren, Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
+import { trpcServer } from '@/src/trpc/trpc-server';
 import { GuestTeamNavbarItem } from '../team-dashboard/navbar/guest-team-navbar-item';
 import { TeamDropdown } from '../team-dashboard/navbar/team-dropdown/team-dropdown.server';
 import { BaseNavbar } from './base-navbar';
@@ -37,11 +37,7 @@ export function Navbar({ children, currentTeam, className }: PropsWithChildren<P
 	);
 }
 
-async function TeamDropdownItem({
-	currentTeam,
-}: {
-	currentTeam?: Pick<TeamSchema, 'slug'>;
-}) {
+async function TeamDropdownItem({ currentTeam }: { currentTeam?: Pick<TeamSchema, 'slug'> }) {
 	noStore();
 
 	const { user } = await trpcServer.user.getSelf.query();

--- a/apps/web/src/components/navbar/profile-menu/profile-menu.client.tsx
+++ b/apps/web/src/components/navbar/profile-menu/profile-menu.client.tsx
@@ -1,5 +1,9 @@
 'use client';
 
+import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
+import type { UserSchema } from '@interval.so/api/app/user/schemas/user_schema';
+import { Link } from 'next-view-transitions';
+import { Suspense, use } from 'react';
 import {
 	DropdownMenuGroup,
 	DropdownMenuItem,
@@ -8,10 +12,6 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useLogOut } from '@/src/hooks/log-out';
-import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
-import type { UserSchema } from '@interval.so/api/app/user/schemas/user_schema';
-import { Link } from 'next-view-transitions';
-import { Suspense, use } from 'react';
 
 export function MenuContentAuthed({ user }: { user: Pick<UserSchema, 'displayName'> }) {
 	const logOut = useLogOut({ redirectTo: '/' });
@@ -47,7 +47,9 @@ function DisplayName({ displayNamePromise }: { displayNamePromise: Promise<TeamS
 
 export function MenuContentGuestAuth({
 	displayNamePromise,
-}: { displayNamePromise: Promise<TeamSchema['displayName']> }) {
+}: {
+	displayNamePromise: Promise<TeamSchema['displayName']>;
+}) {
 	const logOut = useLogOut({ redirectTo: '/' });
 
 	return (

--- a/apps/web/src/components/navbar/profile-menu/profile-menu.tsx
+++ b/apps/web/src/components/navbar/profile-menu/profile-menu.tsx
@@ -1,3 +1,8 @@
+import { UserCircleIcon } from '@heroicons/react/20/solid';
+import { unstable_noStore as noStore } from 'next/cache';
+import { Link } from 'next-view-transitions';
+import { Suspense } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { Button } from '@/components/ui/button';
 import {
 	DropdownMenu,
@@ -9,11 +14,6 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Skeleton } from '@/components/ui/skeleton';
 import { trpcServer } from '@/src/trpc/trpc-server';
-import { UserCircleIcon } from '@heroicons/react/20/solid';
-import { Link } from 'next-view-transitions';
-import { unstable_noStore as noStore } from 'next/cache';
-import { Suspense } from 'react';
-import { ErrorBoundary } from 'react-error-boundary';
 import { MenuContentAuthed, MenuContentGuestAuth } from './profile-menu.client';
 
 function MenuContentUnauthed() {

--- a/apps/web/src/components/not-found-content.tsx
+++ b/apps/web/src/components/not-found-content.tsx
@@ -1,6 +1,6 @@
-import { Button } from '@/components/ui/button';
-import { Link } from 'next-view-transitions';
 import { unstable_noStore as noStore } from 'next/cache';
+import { Link } from 'next-view-transitions';
+import { Button } from '@/components/ui/button';
 import { trpcServer } from '../trpc/trpc-server';
 
 export async function NotFoundPageContent() {

--- a/apps/web/src/components/onboarding/team-invite/invalid-invite-card.tsx
+++ b/apps/web/src/components/onboarding/team-invite/invalid-invite-card.tsx
@@ -1,6 +1,6 @@
+import { Link } from 'next-view-transitions';
 import { Button } from '@/components/ui/button';
 import { Card, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
-import { Link } from 'next-view-transitions';
 
 export function InvalidInviteCard() {
 	return (

--- a/apps/web/src/components/onboarding/team-invite/join-team-button/join-team-button.client.tsx
+++ b/apps/web/src/components/onboarding/team-invite/join-team-button/join-team-button.client.tsx
@@ -1,14 +1,14 @@
 'use client';
 
+import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
+import clsx from 'clsx';
+import { useRouter } from 'next/navigation';
+import { Link } from 'next-view-transitions';
+import { use, useState } from 'react';
+import { toast } from 'sonner';
 import { Button, buttonVariants } from '@/components/ui/button';
 import { searchParamSerializer } from '@/src/components/account/search-params';
 import { trpc } from '@/src/trpc/trpc-client';
-import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
-import clsx from 'clsx';
-import { Link } from 'next-view-transitions';
-import { useRouter } from 'next/navigation';
-import { use, useState } from 'react';
-import { toast } from 'sonner';
 
 type Props = {
 	className?: string;

--- a/apps/web/src/components/onboarding/team-invite/join-team-button/join-team-button.server.tsx
+++ b/apps/web/src/components/onboarding/team-invite/join-team-button/join-team-button.server.tsx
@@ -1,9 +1,9 @@
-import { Skeleton } from '@/components/ui/skeleton';
-import { cn } from '@/lib/utils';
-import { trpcServer } from '@/src/trpc/trpc-server';
 import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import clsx from 'clsx';
 import { Suspense } from 'react';
+import { Skeleton } from '@/components/ui/skeleton';
+import { cn } from '@/lib/utils';
+import { trpcServer } from '@/src/trpc/trpc-server';
 import { JoinTeamButtonClient } from './join-team-button.client';
 
 type Props = {

--- a/apps/web/src/components/onboarding/team-invite/join-team-card.tsx
+++ b/apps/web/src/components/onboarding/team-invite/join-team-card.tsx
@@ -1,9 +1,9 @@
+import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
+import { Suspense } from 'react';
 import { Card, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { isTrpcClientError } from '@/src/trpc/common';
 import { trpcServer } from '@/src/trpc/trpc-server';
-import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
-import { Suspense } from 'react';
 import { InvalidInviteCard } from './invalid-invite-card';
 import { JoinTeamButton } from './join-team-button/join-team-button.server';
 

--- a/apps/web/src/components/page-header.tsx
+++ b/apps/web/src/components/page-header.tsx
@@ -1,7 +1,7 @@
-import { Skeleton } from '@/components/ui/skeleton';
-import { cn } from '@/lib/utils';
 import clsx from 'clsx';
 import { type PropsWithChildren, type ReactNode, Suspense } from 'react';
+import { Skeleton } from '@/components/ui/skeleton';
+import { cn } from '@/lib/utils';
 
 type Props = PropsWithChildren<{
 	title: ReactNode;

--- a/apps/web/src/components/page-wrappers/main-content.tsx
+++ b/apps/web/src/components/page-wrappers/main-content.tsx
@@ -1,5 +1,5 @@
-import { cn } from '@/lib/utils';
 import type { PropsWithChildren } from 'react';
+import { cn } from '@/lib/utils';
 import dotsStyles from '../dots/dots.module.css';
 
 type Props = PropsWithChildren<{

--- a/apps/web/src/components/settings-card-skeleton.tsx
+++ b/apps/web/src/components/settings-card-skeleton.tsx
@@ -1,7 +1,7 @@
+import clsx from 'clsx';
 import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { cn } from '@/lib/utils';
-import clsx from 'clsx';
 
 type Props = {
 	className?: string;

--- a/apps/web/src/components/team-dashboard/attendance-table/attendance-table.tsx
+++ b/apps/web/src/components/team-dashboard/attendance-table/attendance-table.tsx
@@ -1,18 +1,18 @@
 'use client';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/flex-table';
-import { Input } from '@/components/ui/input';
-import { Switch } from '@/components/ui/switch';
-import { trpc } from '@/src/trpc/trpc-client';
 import { PlusIcon } from '@heroicons/react/16/solid';
 import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import type { TeamMemberSchema } from '@interval.so/api/app/team_member/schemas/team_member_schema';
 import { concatIterables } from '@jonahsnider/util';
 import clsx from 'clsx';
-import { AnimatePresence, type Variants, motion } from 'framer-motion';
+import { AnimatePresence, motion, type Variants } from 'framer-motion';
 import Fuse from 'fuse.js/basic';
 import { useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/flex-table';
+import { Input } from '@/components/ui/input';
+import { Switch } from '@/components/ui/switch';
+import { trpc } from '@/src/trpc/trpc-client';
 import { CreateMemberDialog } from '../../members/create-member/create-member-dialog';
 
 const MotionTableRow = motion.create(TableRow);

--- a/apps/web/src/components/team-dashboard/manager-tiles/manage-tile.tsx
+++ b/apps/web/src/components/team-dashboard/manager-tiles/manage-tile.tsx
@@ -1,5 +1,5 @@
-import { Card, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
+import { Card, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { EndMeetingButton } from '../../manager/end-meeting-button/end-meeting-button';
 
 type Props = {

--- a/apps/web/src/components/team-dashboard/manager-tiles/manager-link-tile.tsx
+++ b/apps/web/src/components/team-dashboard/manager-tiles/manager-link-tile.tsx
@@ -1,7 +1,7 @@
-import { Card, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { ArrowRightIcon } from '@heroicons/react/24/solid';
 import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import { Link } from 'next-view-transitions';
+import { Card, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 
 type Props = {
 	team: Pick<TeamSchema, 'slug'>;

--- a/apps/web/src/components/team-dashboard/manager-tiles/member-count-tile/member-count-tile.client.tsx
+++ b/apps/web/src/components/team-dashboard/manager-tiles/member-count-tile/member-count-tile.client.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { trpc } from '@/src/trpc/trpc-client';
 import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import { count } from '@jonahsnider/util';
 import { use, useState } from 'react';
+import { trpc } from '@/src/trpc/trpc-client';
 
 type Props = {
 	team: Pick<TeamSchema, 'slug'>;

--- a/apps/web/src/components/team-dashboard/manager-tiles/member-count-tile/member-count-tile.server.tsx
+++ b/apps/web/src/components/team-dashboard/manager-tiles/member-count-tile/member-count-tile.server.tsx
@@ -1,9 +1,9 @@
-import { Card, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
-import { Skeleton } from '@/components/ui/skeleton';
-import { trpcServer } from '@/src/trpc/trpc-server';
 import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import { count } from '@jonahsnider/util';
 import { Suspense } from 'react';
+import { Card, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { trpcServer } from '@/src/trpc/trpc-server';
 import { MemberAvatars } from '../../member-avatars/member-avatars.server';
 import { MemberCountTileInner } from './member-count-tile.client';
 

--- a/apps/web/src/components/team-dashboard/member-avatars/member-avatars.client.tsx
+++ b/apps/web/src/components/team-dashboard/member-avatars/member-avatars.client.tsx
@@ -1,15 +1,15 @@
 'use client';
 
-import { Avatar, AvatarFallback } from '@/components/ui/avatar';
-import { ScrollArea, ScrollBar } from '@/components/ui/scroll-area';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
-import { trpc } from '@/src/trpc/trpc-client';
 import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import type { TeamMemberSchema } from '@interval.so/api/app/team_member/schemas/team_member_schema';
 import { Sort } from '@jonahsnider/util';
 import clsx from 'clsx';
-import { AnimatePresence, type Variants, motion } from 'framer-motion';
+import { AnimatePresence, motion, type Variants } from 'framer-motion';
 import { use, useState } from 'react';
+import { Avatar, AvatarFallback } from '@/components/ui/avatar';
+import { ScrollArea, ScrollBar } from '@/components/ui/scroll-area';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { trpc } from '@/src/trpc/trpc-client';
 
 type Props = {
 	team: Pick<TeamSchema, 'slug'>;
@@ -70,7 +70,11 @@ function MemberAvatar({
 	member,
 	index,
 	elements,
-}: { member: Pick<TeamMemberSchema, 'name'>; index: number; elements: number }) {
+}: {
+	member: Pick<TeamMemberSchema, 'name'>;
+	index: number;
+	elements: number;
+}) {
 	const [, firstInitial, secondInitial] = FIRST_TWO_INTIALS_REGEXP.exec(member.name) ?? [];
 
 	return (

--- a/apps/web/src/components/team-dashboard/member-avatars/member-avatars.server.tsx
+++ b/apps/web/src/components/team-dashboard/member-avatars/member-avatars.server.tsx
@@ -1,7 +1,7 @@
-import { trpcServer } from '@/src/trpc/trpc-server';
 import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import { Sort } from '@jonahsnider/util';
 import { Suspense } from 'react';
+import { trpcServer } from '@/src/trpc/trpc-server';
 import { MemberAvatarsClient } from './member-avatars.client';
 
 type Props = {

--- a/apps/web/src/components/team-dashboard/navbar/guest-team-navbar-item.tsx
+++ b/apps/web/src/components/team-dashboard/navbar/guest-team-navbar-item.tsx
@@ -1,8 +1,8 @@
-import { Skeleton } from '@/components/ui/skeleton';
-import { trpcServer } from '@/src/trpc/trpc-server';
 import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import { Suspense, use } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
+import { Skeleton } from '@/components/ui/skeleton';
+import { trpcServer } from '@/src/trpc/trpc-server';
 import { SlashSeparatedNavbarItem } from './slash-separated-navbar-item';
 
 type Props = {
@@ -21,11 +21,7 @@ export function GuestTeamNavbarItem() {
 	);
 }
 
-function GuestTeamNavbarItemInner({
-	teamPromise,
-}: {
-	teamPromise: Promise<Pick<TeamSchema, 'slug'> | undefined>;
-}) {
+function GuestTeamNavbarItemInner({ teamPromise }: { teamPromise: Promise<Pick<TeamSchema, 'slug'> | undefined> }) {
 	const team = use(teamPromise);
 
 	if (!team) {

--- a/apps/web/src/components/team-dashboard/navbar/team-dropdown/team-dropdown.client.tsx
+++ b/apps/web/src/components/team-dashboard/navbar/team-dropdown/team-dropdown.client.tsx
@@ -1,5 +1,11 @@
 'use client';
 
+import { ChevronUpDownIcon, PlusIcon } from '@heroicons/react/16/solid';
+import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
+import clsx from 'clsx';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { Link } from 'next-view-transitions';
+import { type ReactNode, use, useContext, useEffect, useMemo } from 'react';
 import { Button } from '@/components/ui/button';
 import {
 	DropdownMenu,
@@ -11,12 +17,6 @@ import {
 	DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { PostHogTeamIdContext } from '@/src/providers/post-hog-team-id-provider';
-import { ChevronUpDownIcon, PlusIcon } from '@heroicons/react/16/solid';
-import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
-import clsx from 'clsx';
-import { Link } from 'next-view-transitions';
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { type ReactNode, use, useContext, useEffect, useMemo } from 'react';
 import { TeamSlugContext } from '../../team-slug-provider';
 import { SlashSeparatedNavbarItem } from '../slash-separated-navbar-item';
 

--- a/apps/web/src/components/team-dashboard/navbar/team-dropdown/team-dropdown.server.tsx
+++ b/apps/web/src/components/team-dashboard/navbar/team-dropdown/team-dropdown.server.tsx
@@ -1,3 +1,7 @@
+import { PlusIcon } from '@heroicons/react/16/solid';
+import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
+import { Link } from 'next-view-transitions';
+import { Suspense } from 'react';
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -7,10 +11,6 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Skeleton } from '@/components/ui/skeleton';
 import { trpcServer } from '@/src/trpc/trpc-server';
-import { PlusIcon } from '@heroicons/react/16/solid';
-import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
-import { Link } from 'next-view-transitions';
-import { Suspense } from 'react';
 import { TeamDropdownClient, TeamDropdownTrigger } from './team-dropdown.client';
 
 function TeamDropdownSkeleton({ currentTeam }: { currentTeam?: Pick<TeamSchema, 'slug'> }) {

--- a/apps/web/src/components/team-dashboard/password-login/already-authed-card.tsx
+++ b/apps/web/src/components/team-dashboard/password-login/already-authed-card.tsx
@@ -1,10 +1,10 @@
 'use client';
 
+import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
+import { Link } from 'next-view-transitions';
 import { Button } from '@/components/ui/button';
 import { Card, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { useLogOut } from '@/src/hooks/log-out';
-import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
-import { Link } from 'next-view-transitions';
 
 type Props = {
 	team: Pick<TeamSchema, 'slug' | 'displayName'>;

--- a/apps/web/src/components/team-dashboard/password-login/password-login-card.tsx
+++ b/apps/web/src/components/team-dashboard/password-login/password-login-card.tsx
@@ -1,10 +1,5 @@
 'use client';
 
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
-import { Input } from '@/components/ui/input';
-import { trpc } from '@/src/trpc/trpc-client';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import { useRouter } from 'next/navigation';
@@ -12,6 +7,11 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import type { z } from 'zod';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { trpc } from '@/src/trpc/trpc-client';
 
 const formSchema = TeamSchema.pick({
 	password: true,

--- a/apps/web/src/components/team-dashboard/team-slug-provider.tsx
+++ b/apps/web/src/components/team-dashboard/team-slug-provider.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
-import { type PropsWithChildren, createContext } from 'react';
+import { createContext, type PropsWithChildren } from 'react';
 
 type ContextValue = {
 	team?: Pick<TeamSchema, 'slug'>;

--- a/apps/web/src/providers/post-hog-page-view.tsx
+++ b/apps/web/src/providers/post-hog-page-view.tsx
@@ -17,7 +17,6 @@ function RawPostHogPageView(): undefined {
 				url += `?${searchParams.toString()}`;
 			}
 			posthog.capture('$pageview', {
-				// biome-ignore lint/style/useNamingConvention: This can't be renamed
 				$current_url: url,
 			});
 		}

--- a/apps/web/src/providers/post-hog-provider.tsx
+++ b/apps/web/src/providers/post-hog-provider.tsx
@@ -8,9 +8,7 @@ export function CsPostHogProvider({ children }: PropsWithChildren) {
 	useEffect(() => {
 		if (process.env.POSTHOG_KEY) {
 			posthog.init(process.env.POSTHOG_KEY, {
-				// biome-ignore lint/style/useNamingConvention: This can't be renamed
 				api_host: process.env.POSTHOG_HOST,
-				// biome-ignore lint/style/useNamingConvention: This can't be renamed
 				person_profiles: 'identified_only', // or 'always' to create profiles for anonymous users as well
 			});
 		}

--- a/apps/web/src/providers/post-hog-team-id-provider.tsx
+++ b/apps/web/src/providers/post-hog-team-id-provider.tsx
@@ -2,7 +2,7 @@
 
 import type { TeamSchema } from '@interval.so/api/app/team/schemas/team_schema';
 import posthog from 'posthog-js';
-import { type PropsWithChildren, createContext, useCallback, useMemo, useState } from 'react';
+import { createContext, type PropsWithChildren, useCallback, useMemo, useState } from 'react';
 
 type ContextValue = {
 	currentTeam: Pick<TeamSchema, 'id'> | undefined;

--- a/apps/web/src/trpc/common.ts
+++ b/apps/web/src/trpc/common.ts
@@ -1,7 +1,7 @@
-import getBaseApiUrl from '@/shared';
 import type { AppRouterType } from '@interval.so/api/trpc_entry';
 import { TRPCClientError } from '@trpc/client';
 import type { inferRouterInputs, inferRouterOutputs } from '@trpc/server';
+import getBaseApiUrl from '@/shared';
 
 export const trpcUrl = new URL('/trpc', getBaseApiUrl());
 export const trpcWsUrl = new URL('/trpc', getBaseApiUrl());

--- a/apps/web/src/trpc/trpc-client.ts
+++ b/apps/web/src/trpc/trpc-client.ts
@@ -1,6 +1,6 @@
 import {
-	type HTTPBatchLinkOptions,
 	createWSClient,
+	type HTTPBatchLinkOptions,
 	httpBatchLink,
 	httpBatchStreamLink,
 	splitLink,

--- a/apps/web/src/utils/date-format.ts
+++ b/apps/web/src/utils/date-format.ts
@@ -1,7 +1,7 @@
 import { capitalize, multiReplace } from '@jonahsnider/util';
 import {
-	type Duration,
 	add,
+	type Duration,
 	formatDistance as formatDistanceDateFns,
 	formatRelative,
 	isWithinInterval,

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -19,31 +19,26 @@ module.exports = {
 			colors: {
 				border: 'hsl(var(--border))',
 				input: {
-					// biome-ignore lint/style/useNamingConvention: This can't be renamed
 					DEFAULT: 'hsl(var(--input))',
 					border: 'hsl(var(--input-border))',
 				},
 				ring: 'hsl(var(--ring))',
 				background: {
-					// biome-ignore lint/style/useNamingConvention: This can't be renamed
 					DEFAULT: 'hsl(var(--background))',
 					muted: 'hsl(var(--background-muted))',
 				},
 				foreground: 'hsl(var(--foreground))',
 				primary: {
-					// biome-ignore lint/style/useNamingConvention: This can't be renamed
 					DEFAULT: 'hsl(var(--primary))',
 					foreground: 'hsl(var(--primary-foreground))',
 					hover: 'hsl(var(--primary-hover))',
 				},
 				secondary: {
-					// biome-ignore lint/style/useNamingConvention: This can't be renamed
 					DEFAULT: 'hsl(var(--secondary))',
 					foreground: 'hsl(var(--secondary-foreground))',
 					hover: 'hsl(var(--secondary-hover))',
 				},
 				destructive: {
-					// biome-ignore lint/style/useNamingConvention: This can't be renamed
 					DEFAULT: 'hsl(var(--destructive))',
 					foreground: 'hsl(var(--destructive-foreground))',
 					muted: 'hsl(var(--destructive-muted))',
@@ -51,22 +46,18 @@ module.exports = {
 					border: 'hsl(var(--destructive-border))',
 				},
 				muted: {
-					// biome-ignore lint/style/useNamingConvention: This can't be renamed
 					DEFAULT: 'hsl(var(--muted))',
 					foreground: 'hsl(var(--muted-foreground))',
 				},
 				accent: {
-					// biome-ignore lint/style/useNamingConvention: This can't be renamed
 					DEFAULT: 'hsl(var(--accent))',
 					foreground: 'hsl(var(--accent-foreground))',
 				},
 				popover: {
-					// biome-ignore lint/style/useNamingConvention: This can't be renamed
 					DEFAULT: 'hsl(var(--popover))',
 					foreground: 'hsl(var(--popover-foreground))',
 				},
 				card: {
-					// biome-ignore lint/style/useNamingConvention: This can't be renamed
 					DEFAULT: 'hsl(var(--card))',
 					foreground: 'hsl(var(--card-foreground))',
 				},

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.0.6/schema.json",
 	"files": {
 		"includes": [
 			"**",

--- a/biome.json
+++ b/biome.json
@@ -44,24 +44,11 @@
 			},
 			"style": {
 				"noParameterProperties": "off",
-				"useDefaultSwitchClause": "off",
-				"noParameterAssign": "error",
-				"useAsConstAssertion": "error",
-				"useDefaultParameterLast": "error",
-				"useEnumInitializers": "error",
-				"useSelfClosingElements": "error",
-				"useSingleVarDeclarator": "error",
-				"noUnusedTemplateLiteral": "error",
-				"useNumberNamespace": "error",
-				"noInferrableTypes": "error",
-				"noUselessElse": "error"
+				"useDefaultSwitchClause": "off"
 			},
 			"suspicious": {
 				"noEmptyBlockStatements": "off",
 				"noReactSpecificProps": "off"
-			},
-			"performance": {
-				"noNamespaceImport": "off"
 			}
 		}
 	}

--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,15 @@
 {
-	"$schema": "https://biomejs.dev/schemas/1.9.0/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
 	"files": {
-		"ignore": [".next", "node_modules", ".vercel", "**/package.json", "apps/api/build", ".turbo"]
+		"includes": [
+			"**",
+			"!**/.next",
+			"!**/node_modules",
+			"!**/.vercel",
+			"!**/package.json",
+			"!**/apps/api/build",
+			"!**/.turbo"
+		]
 	},
 	"formatter": {
 		"formatWithErrors": true,
@@ -23,9 +31,8 @@
 		}
 	},
 	"linter": {
-		"ignore": ["apps/api/app/user/schemas/postgres_timezones.ts"],
+		"includes": ["**", "!**/apps/api/app/user/schemas/postgres_timezones.ts"],
 		"rules": {
-			"all": true,
 			"complexity": {
 				"noStaticOnlyClass": "off",
 				"useLiteralKeys": "off"
@@ -36,13 +43,25 @@
 				"useImportExtensions": "off"
 			},
 			"style": {
-				"noNamespaceImport": "off",
 				"noParameterProperties": "off",
-				"useDefaultSwitchClause": "off"
+				"useDefaultSwitchClause": "off",
+				"noParameterAssign": "error",
+				"useAsConstAssertion": "error",
+				"useDefaultParameterLast": "error",
+				"useEnumInitializers": "error",
+				"useSelfClosingElements": "error",
+				"useSingleVarDeclarator": "error",
+				"noUnusedTemplateLiteral": "error",
+				"useNumberNamespace": "error",
+				"noInferrableTypes": "error",
+				"noUselessElse": "error"
 			},
 			"suspicious": {
 				"noEmptyBlockStatements": "off",
 				"noReactSpecificProps": "off"
+			},
+			"performance": {
+				"noNamespaceImport": "off"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"react-is": "^19.0.0-rc-69d4b800-20241021"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "1.9.4",
+		"@biomejs/biome": "2.0.0",
 		"prettier": "3.6.2",
 		"prettier-plugin-packagejson": "2.5.18",
 		"turbo": "2.5.4",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"react-is": "^19.0.0-rc-69d4b800-20241021"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.0.0",
+		"@biomejs/biome": "2.0.6",
 		"prettier": "3.6.2",
 		"prettier-plugin-packagejson": "2.5.18",
 		"turbo": "2.5.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -698,18 +698,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@biomejs/biome@npm:2.0.0":
-  version: 2.0.0
-  resolution: "@biomejs/biome@npm:2.0.0"
+"@biomejs/biome@npm:2.0.6":
+  version: 2.0.6
+  resolution: "@biomejs/biome@npm:2.0.6"
   dependencies:
-    "@biomejs/cli-darwin-arm64": "npm:2.0.0"
-    "@biomejs/cli-darwin-x64": "npm:2.0.0"
-    "@biomejs/cli-linux-arm64": "npm:2.0.0"
-    "@biomejs/cli-linux-arm64-musl": "npm:2.0.0"
-    "@biomejs/cli-linux-x64": "npm:2.0.0"
-    "@biomejs/cli-linux-x64-musl": "npm:2.0.0"
-    "@biomejs/cli-win32-arm64": "npm:2.0.0"
-    "@biomejs/cli-win32-x64": "npm:2.0.0"
+    "@biomejs/cli-darwin-arm64": "npm:2.0.6"
+    "@biomejs/cli-darwin-x64": "npm:2.0.6"
+    "@biomejs/cli-linux-arm64": "npm:2.0.6"
+    "@biomejs/cli-linux-arm64-musl": "npm:2.0.6"
+    "@biomejs/cli-linux-x64": "npm:2.0.6"
+    "@biomejs/cli-linux-x64-musl": "npm:2.0.6"
+    "@biomejs/cli-win32-arm64": "npm:2.0.6"
+    "@biomejs/cli-win32-x64": "npm:2.0.6"
   dependenciesMeta:
     "@biomejs/cli-darwin-arm64":
       optional: true
@@ -729,62 +729,62 @@ __metadata:
       optional: true
   bin:
     biome: bin/biome
-  checksum: 10c0/a255d2e84e303c6b1bd841877463f358415a35fb39dc4051dec80d9dd44e4f2f546e7e13804f7cd9f0932ca11664600f819e0b0dd75c55c2c0571ed771d86cb5
+  checksum: 10c0/eafaf3981580314c08085542152396f3417637d08d7b8aaee6a5173a978435d7688b1b6b547096e3a9d3573f03cfe526f7342dd341143c322c03d545df126f18
   languageName: node
   linkType: hard
 
-"@biomejs/cli-darwin-arm64@npm:2.0.0":
-  version: 2.0.0
-  resolution: "@biomejs/cli-darwin-arm64@npm:2.0.0"
+"@biomejs/cli-darwin-arm64@npm:2.0.6":
+  version: 2.0.6
+  resolution: "@biomejs/cli-darwin-arm64@npm:2.0.6"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@biomejs/cli-darwin-x64@npm:2.0.0":
-  version: 2.0.0
-  resolution: "@biomejs/cli-darwin-x64@npm:2.0.0"
+"@biomejs/cli-darwin-x64@npm:2.0.6":
+  version: 2.0.6
+  resolution: "@biomejs/cli-darwin-x64@npm:2.0.6"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@biomejs/cli-linux-arm64-musl@npm:2.0.0":
-  version: 2.0.0
-  resolution: "@biomejs/cli-linux-arm64-musl@npm:2.0.0"
+"@biomejs/cli-linux-arm64-musl@npm:2.0.6":
+  version: 2.0.6
+  resolution: "@biomejs/cli-linux-arm64-musl@npm:2.0.6"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@biomejs/cli-linux-arm64@npm:2.0.0":
-  version: 2.0.0
-  resolution: "@biomejs/cli-linux-arm64@npm:2.0.0"
+"@biomejs/cli-linux-arm64@npm:2.0.6":
+  version: 2.0.6
+  resolution: "@biomejs/cli-linux-arm64@npm:2.0.6"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@biomejs/cli-linux-x64-musl@npm:2.0.0":
-  version: 2.0.0
-  resolution: "@biomejs/cli-linux-x64-musl@npm:2.0.0"
+"@biomejs/cli-linux-x64-musl@npm:2.0.6":
+  version: 2.0.6
+  resolution: "@biomejs/cli-linux-x64-musl@npm:2.0.6"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@biomejs/cli-linux-x64@npm:2.0.0":
-  version: 2.0.0
-  resolution: "@biomejs/cli-linux-x64@npm:2.0.0"
+"@biomejs/cli-linux-x64@npm:2.0.6":
+  version: 2.0.6
+  resolution: "@biomejs/cli-linux-x64@npm:2.0.6"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@biomejs/cli-win32-arm64@npm:2.0.0":
-  version: 2.0.0
-  resolution: "@biomejs/cli-win32-arm64@npm:2.0.0"
+"@biomejs/cli-win32-arm64@npm:2.0.6":
+  version: 2.0.6
+  resolution: "@biomejs/cli-win32-arm64@npm:2.0.6"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@biomejs/cli-win32-x64@npm:2.0.0":
-  version: 2.0.0
-  resolution: "@biomejs/cli-win32-x64@npm:2.0.0"
+"@biomejs/cli-win32-x64@npm:2.0.6":
+  version: 2.0.6
+  resolution: "@biomejs/cli-win32-x64@npm:2.0.6"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -8558,7 +8558,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "interval.so@workspace:."
   dependencies:
-    "@biomejs/biome": "npm:2.0.0"
+    "@biomejs/biome": "npm:2.0.6"
     prettier: "npm:3.6.2"
     prettier-plugin-packagejson: "npm:2.5.18"
     turbo: "npm:2.5.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -698,18 +698,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@biomejs/biome@npm:1.9.4":
-  version: 1.9.4
-  resolution: "@biomejs/biome@npm:1.9.4"
+"@biomejs/biome@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@biomejs/biome@npm:2.0.0"
   dependencies:
-    "@biomejs/cli-darwin-arm64": "npm:1.9.4"
-    "@biomejs/cli-darwin-x64": "npm:1.9.4"
-    "@biomejs/cli-linux-arm64": "npm:1.9.4"
-    "@biomejs/cli-linux-arm64-musl": "npm:1.9.4"
-    "@biomejs/cli-linux-x64": "npm:1.9.4"
-    "@biomejs/cli-linux-x64-musl": "npm:1.9.4"
-    "@biomejs/cli-win32-arm64": "npm:1.9.4"
-    "@biomejs/cli-win32-x64": "npm:1.9.4"
+    "@biomejs/cli-darwin-arm64": "npm:2.0.0"
+    "@biomejs/cli-darwin-x64": "npm:2.0.0"
+    "@biomejs/cli-linux-arm64": "npm:2.0.0"
+    "@biomejs/cli-linux-arm64-musl": "npm:2.0.0"
+    "@biomejs/cli-linux-x64": "npm:2.0.0"
+    "@biomejs/cli-linux-x64-musl": "npm:2.0.0"
+    "@biomejs/cli-win32-arm64": "npm:2.0.0"
+    "@biomejs/cli-win32-x64": "npm:2.0.0"
   dependenciesMeta:
     "@biomejs/cli-darwin-arm64":
       optional: true
@@ -729,62 +729,62 @@ __metadata:
       optional: true
   bin:
     biome: bin/biome
-  checksum: 10c0/b5655c5aed9a6fffe24f7d04f15ba4444389d0e891c9ed9106fab7388ac9b4be63185852cc2a937b22940dac3e550b71032a4afd306925cfea436c33e5646b3e
+  checksum: 10c0/a255d2e84e303c6b1bd841877463f358415a35fb39dc4051dec80d9dd44e4f2f546e7e13804f7cd9f0932ca11664600f819e0b0dd75c55c2c0571ed771d86cb5
   languageName: node
   linkType: hard
 
-"@biomejs/cli-darwin-arm64@npm:1.9.4":
-  version: 1.9.4
-  resolution: "@biomejs/cli-darwin-arm64@npm:1.9.4"
+"@biomejs/cli-darwin-arm64@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@biomejs/cli-darwin-arm64@npm:2.0.0"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@biomejs/cli-darwin-x64@npm:1.9.4":
-  version: 1.9.4
-  resolution: "@biomejs/cli-darwin-x64@npm:1.9.4"
+"@biomejs/cli-darwin-x64@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@biomejs/cli-darwin-x64@npm:2.0.0"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@biomejs/cli-linux-arm64-musl@npm:1.9.4":
-  version: 1.9.4
-  resolution: "@biomejs/cli-linux-arm64-musl@npm:1.9.4"
+"@biomejs/cli-linux-arm64-musl@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@biomejs/cli-linux-arm64-musl@npm:2.0.0"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@biomejs/cli-linux-arm64@npm:1.9.4":
-  version: 1.9.4
-  resolution: "@biomejs/cli-linux-arm64@npm:1.9.4"
+"@biomejs/cli-linux-arm64@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@biomejs/cli-linux-arm64@npm:2.0.0"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@biomejs/cli-linux-x64-musl@npm:1.9.4":
-  version: 1.9.4
-  resolution: "@biomejs/cli-linux-x64-musl@npm:1.9.4"
+"@biomejs/cli-linux-x64-musl@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@biomejs/cli-linux-x64-musl@npm:2.0.0"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@biomejs/cli-linux-x64@npm:1.9.4":
-  version: 1.9.4
-  resolution: "@biomejs/cli-linux-x64@npm:1.9.4"
+"@biomejs/cli-linux-x64@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@biomejs/cli-linux-x64@npm:2.0.0"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@biomejs/cli-win32-arm64@npm:1.9.4":
-  version: 1.9.4
-  resolution: "@biomejs/cli-win32-arm64@npm:1.9.4"
+"@biomejs/cli-win32-arm64@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@biomejs/cli-win32-arm64@npm:2.0.0"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@biomejs/cli-win32-x64@npm:1.9.4":
-  version: 1.9.4
-  resolution: "@biomejs/cli-win32-x64@npm:1.9.4"
+"@biomejs/cli-win32-x64@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@biomejs/cli-win32-x64@npm:2.0.0"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -8558,7 +8558,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "interval.so@workspace:."
   dependencies:
-    "@biomejs/biome": "npm:1.9.4"
+    "@biomejs/biome": "npm:2.0.0"
     prettier: "npm:3.6.2"
     prettier-plugin-packagejson: "npm:2.5.18"
     turbo: "npm:2.5.4"


### PR DESCRIPTION
Update Biome to v2 and migrate configuration to leverage new features and resolve breaking changes.

The migration involved updating the package, running the official migration command, and then resolving numerous linting issues. This included removing over 100 unused `biome-ignore` comments (due to rule renames, removals, or changes in default enabled rules like `noDefaultExport` and `useNamingConvention`) and adding a suppression for the CSS Modules-specific `:global` pseudo-class. All linting errors and warnings are now resolved.